### PR TITLE
Fix emulation accuracy: resolution, 68K instructions, RAM init, logging

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -190,6 +190,10 @@ jobs:
           -o test_blitter_scalar test/test_blitter_simd.c src/blitter_simd_scalar.c
         ./test_blitter_scalar
 
+        echo "==> DSP 40-bit MAC accumulator regression (dsp_acc40.h)..."
+        $CC -O2 -Wall -I src -o test_dsp_mac40 test/test_dsp_mac40.c
+        ./test_dsp_mac40
+
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -169,6 +169,11 @@ jobs:
         ${{ steps.setup-ndk.outputs.ndk-path }}/ndk-build \
           APP_ABI=${{ matrix.config.android_abi }} -j4
 
+    # Host/native toolchains only — skips cross-compile rows (e.g. aarch64 on x86 runner).
+    - name: Run cheat engine unit tests
+      if: ${{ !matrix.config.emscripten && !matrix.config.android && !matrix.config.cross }}
+      run: make test CC="${{ matrix.config.cc }}"
+
     - name: Run SIMD blitter tests
       if: ${{ !matrix.config.emscripten && !matrix.config.android && !matrix.config.cross }}
       run: |
@@ -226,7 +231,7 @@ jobs:
           src\gpu.c src\jaguar.c src\jerry.c src\tom.c src\op.c ^
           src\cdintf.c src\cdrom.c src\crc32.c src\event.c ^
           src\eeprom.c src\filedb.c src\joystick.c src\settings.c ^
-          src\memtrack.c src\mmu.c src\vjag_memory.c ^
+          src\memtrack.c src\mmu.c src\vjag_memory.c src\cheat.c ^
           src\universalhdr.c src\wavetable.c ^
           src\jagbios.c src\jagbios2.c ^
           src\jagcdbios.c src\jagdevcdbios.c ^

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -199,6 +199,33 @@ jobs:
         $CC -O2 -Wall -I src -o test_dsp_mac40 test/test_dsp_mac40.c
         ./test_dsp_mac40
 
+    - name: Run memory map test
+      if: ${{ !matrix.config.emscripten && !matrix.config.android && !matrix.config.cross && runner.os != 'Windows' }}
+      run: |
+        CC="${{ matrix.config.cc }}"
+        if [ "$(uname)" = "Linux" ]; then
+          LDFLAGS="-ldl"
+        else
+          LDFLAGS=""
+        fi
+        $CC -O2 -Wall -o test/tools/test_memory_map test/tools/test_memory_map.c $LDFLAGS
+        ./test/tools/test_memory_map ./${{ matrix.config.artifact }}
+
+    - name: Cache pinned rcheevos E2E build
+      if: ${{ !matrix.config.emscripten && !matrix.config.android && !matrix.config.cross && runner.os != 'Windows' }}
+      uses: actions/cache@v4
+      with:
+        path: build/rcheevos-static
+        key: rcheevos-e2e-fd57e900-${{ runner.os }}-${{ matrix.config.cc }}-${{ matrix.config.displayTargetName }}
+
+    - name: RetroAchievements rc_libretro E2E test
+      if: ${{ !matrix.config.emscripten && !matrix.config.android && !matrix.config.cross && runner.os != 'Windows' }}
+      env:
+        # Immutable pin (rcheevos v12.3.0); tarball via .../archive/${SHA}.tar.gz
+        RCHEEVOS_REF: fd57e900758a9e3de343e7b0316b8a6059dce228
+        CC: ${{ matrix.config.cc }}
+      run: bash test/tools/test_rcheevos_e2e.sh ./${{ matrix.config.artifact }}
+
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -31,6 +32,13 @@ jobs:
             cc: 'gcc'
             cxx: 'g++'
 
+          - displayTargetName: 'Linux i686'
+            artifact: 'virtualjaguar_libretro.so'
+            os: ubuntu-latest
+            cc: 'gcc -m32'
+            cxx: 'g++ -m32'
+            multilib: true
+
           # macOS
           - displayTargetName: 'macOS arm64 (Clang)'
             artifact: 'virtualjaguar_libretro.dylib'
@@ -45,12 +53,51 @@ jobs:
             cc: 'gcc'
             cxx: 'g++'
             shell: 'msys2 {0}'
+            msystem: 'MINGW64'
+            msys2_packages: 'mingw-w64-x86_64-gcc make'
+
+          - displayTargetName: 'Windows i686 (MSYS2)'
+            artifact: 'virtualjaguar_libretro.dll'
+            os: windows-latest
+            cc: 'gcc'
+            cxx: 'g++'
+            shell: 'msys2 {0}'
+            msystem: 'MINGW32'
+            msys2_packages: 'mingw-w64-i686-gcc make'
 
           # Emscripten (WebAssembly)
           - displayTargetName: 'Emscripten (WASM)'
             artifact: 'virtualjaguar_libretro_emscripten.bc'
             os: ubuntu-latest
             emscripten: true
+
+          # Android NDK (arm64-v8a)
+          - displayTargetName: 'Android arm64-v8a'
+            artifact: 'libs/arm64-v8a/libretro.so'
+            os: ubuntu-latest
+            android: true
+            android_abi: 'arm64-v8a'
+
+          # Android NDK (armeabi-v7a)
+          - displayTargetName: 'Android armeabi-v7a'
+            artifact: 'libs/armeabi-v7a/libretro.so'
+            os: ubuntu-latest
+            android: true
+            android_abi: 'armeabi-v7a'
+
+          # iOS
+          - displayTargetName: 'iOS arm64'
+            artifact: 'virtualjaguar_libretro_ios.dylib'
+            os: macos-latest
+            make_platform: 'ios-arm64'
+            cross: true
+
+          # tvOS
+          - displayTargetName: 'tvOS arm64'
+            artifact: 'virtualjaguar_libretro_tvos.dylib'
+            os: macos-latest
+            make_platform: 'tvos-arm64'
+            cross: true
 
     name: build-${{ matrix.config.displayTargetName }}
     runs-on: ${{ matrix.config.os }}
@@ -62,32 +109,55 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install multilib
+      if: matrix.config.multilib
+      run: |
+        sudo dpkg --add-architecture i386
+        sudo apt-get update
+        sudo apt-get install -y gcc-multilib g++-multilib
+
     - name: Set up MSYS2
       if: runner.os == 'Windows'
       uses: msys2/setup-msys2@v2
       with:
-        msystem: MINGW64
+        msystem: ${{ matrix.config.msystem || 'MINGW64' }}
         update: false
-        install: >-
-          mingw-w64-x86_64-gcc
-          make
+        install: ${{ matrix.config.msys2_packages || 'mingw-w64-x86_64-gcc make' }}
 
     - name: Set up Emscripten
       if: matrix.config.emscripten
       uses: mymindstorm/setup-emsdk@v14
 
+    - name: Set up Android NDK
+      if: matrix.config.android
+      uses: nttld/setup-ndk@v1
+      id: setup-ndk
+      with:
+        ndk-version: r26d
+
     - name: Build
-      if: ${{ !matrix.config.emscripten }}
-      run: make -j4 CC=${{ matrix.config.cc }} CXX=${{ matrix.config.cxx }}
+      if: ${{ !matrix.config.emscripten && !matrix.config.android && !matrix.config.make_platform }}
+      run: make -j4 CC="${{ matrix.config.cc }}" CXX="${{ matrix.config.cxx }}"
+
+    - name: Build (platform)
+      if: matrix.config.make_platform
+      run: make -j4 platform=${{ matrix.config.make_platform }}
 
     - name: Build (Emscripten)
       if: matrix.config.emscripten
       run: emmake make -j4 platform=emscripten
 
+    - name: Build (Android NDK)
+      if: matrix.config.android
+      run: |
+        ${{ steps.setup-ndk.outputs.ndk-path }}/ndk-build \
+          APP_ABI=${{ matrix.config.android_abi }} -j4
+
     - name: Run SIMD blitter tests
-      if: ${{ !matrix.config.emscripten }}
+      if: ${{ !matrix.config.emscripten && !matrix.config.android && !matrix.config.cross }}
       run: |
         ARCH=$(uname -m)
+        CC="${{ matrix.config.cc }}"
         case "$ARCH" in
           x86_64|i686|i386)  SIMD_SRC=src/blitter_simd_sse2.c; EXTRA="-msse2" ;;
           aarch64|arm64)     SIMD_SRC=src/blitter_simd_neon.c;  EXTRA="" ;;
@@ -95,12 +165,12 @@ jobs:
         esac
 
         echo "==> Testing ${SIMD_SRC}..."
-        ${{ matrix.config.cc }} -O2 -Wall ${EXTRA} -I src \
+        $CC -O2 -Wall ${EXTRA} -I src \
           -o test_blitter_simd test/test_blitter_simd.c ${SIMD_SRC}
         ./test_blitter_simd
 
         echo "==> Cross-checking against scalar..."
-        ${{ matrix.config.cc }} -O2 -Wall -I src \
+        $CC -O2 -Wall -I src \
           -o test_blitter_scalar test/test_blitter_simd.c src/blitter_simd_scalar.c
         ./test_blitter_scalar
 
@@ -110,3 +180,32 @@ jobs:
         name: ${{ matrix.config.displayTargetName }}
         path: ${{ matrix.config.artifact }}
         if-no-files-found: error
+
+  c89-lint:
+    name: C89 compliance check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Check for declaration-after-statement
+      run: |
+        echo "==> Checking C89 compliance (catches MSVC C89 errors)..."
+        FAILED=0
+        for f in libretro.c src/*.c; do
+          # Skip machine-generated files
+          case "$f" in
+            src/m68000/*|src/jag*bios*.c|src/jagstub*bios.c|src/blitter_simd_neon.c|src/blitter_simd_sse2.c) continue ;;
+          esac
+          if ! gcc -fsyntax-only -std=gnu89 \
+              -Werror=declaration-after-statement \
+              -I. -Isrc -Isrc/m68000 -Ilibretro-common/include \
+              -D__LIBRETRO__ -DINLINE="inline" \
+              "$f" 2>&1; then
+            FAILED=1
+          fi
+        done
+        if [ "$FAILED" = "1" ]; then
+          echo "::error::C89 compliance check failed — mid-block declarations found"
+          exit 1
+        fi
+        echo "==> All files pass C89 declaration check"

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -46,6 +46,12 @@ jobs:
             cxx: 'g++'
             shell: 'msys2 {0}'
 
+          # Emscripten (WebAssembly)
+          - displayTargetName: 'Emscripten (WASM)'
+            artifact: 'virtualjaguar_libretro_emscripten.bc'
+            os: ubuntu-latest
+            emscripten: true
+
     name: build-${{ matrix.config.displayTargetName }}
     runs-on: ${{ matrix.config.os }}
 
@@ -66,12 +72,21 @@ jobs:
           mingw-w64-x86_64-gcc
           make
 
+    - name: Set up Emscripten
+      if: matrix.config.emscripten
+      uses: mymindstorm/setup-emsdk@v14
+
     - name: Build
+      if: ${{ !matrix.config.emscripten }}
       run: make -j4 CC=${{ matrix.config.cc }} CXX=${{ matrix.config.cxx }}
 
+    - name: Build (Emscripten)
+      if: matrix.config.emscripten
+      run: emmake make -j4 platform=emscripten
+
     - name: Run SIMD blitter tests
+      if: ${{ !matrix.config.emscripten }}
       run: |
-        # Detect which SIMD impl to test based on runner architecture
         ARCH=$(uname -m)
         case "$ARCH" in
           x86_64|i686|i386)  SIMD_SRC=src/blitter_simd_sse2.c; EXTRA="-msse2" ;;

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -46,7 +46,13 @@ jobs:
             cc: 'clang'
             cxx: 'clang++'
 
-          # Windows
+          - displayTargetName: 'macOS x86_64 (Clang)'
+            artifact: 'virtualjaguar_libretro.dylib'
+            os: macos-13
+            cc: 'clang'
+            cxx: 'clang++'
+
+          # Windows (MinGW)
           - displayTargetName: 'Windows x86_64 (MSYS2)'
             artifact: 'virtualjaguar_libretro.dll'
             os: windows-latest
@@ -71,28 +77,38 @@ jobs:
             os: ubuntu-latest
             emscripten: true
 
-          # Android NDK (arm64-v8a)
+          # Android NDK
           - displayTargetName: 'Android arm64-v8a'
             artifact: 'libs/arm64-v8a/libretro.so'
             os: ubuntu-latest
             android: true
             android_abi: 'arm64-v8a'
 
-          # Android NDK (armeabi-v7a)
           - displayTargetName: 'Android armeabi-v7a'
             artifact: 'libs/armeabi-v7a/libretro.so'
             os: ubuntu-latest
             android: true
             android_abi: 'armeabi-v7a'
 
-          # iOS
+          - displayTargetName: 'Android x86_64'
+            artifact: 'libs/x86_64/libretro.so'
+            os: ubuntu-latest
+            android: true
+            android_abi: 'x86_64'
+
+          - displayTargetName: 'Android x86'
+            artifact: 'libs/x86/libretro.so'
+            os: ubuntu-latest
+            android: true
+            android_abi: 'x86'
+
+          # iOS / tvOS
           - displayTargetName: 'iOS arm64'
             artifact: 'virtualjaguar_libretro_ios.dylib'
             os: macos-latest
             make_platform: 'ios-arm64'
             cross: true
 
-          # tvOS
           - displayTargetName: 'tvOS arm64'
             artifact: 'virtualjaguar_libretro_tvos.dylib'
             os: macos-latest
@@ -181,6 +197,79 @@ jobs:
         path: ${{ matrix.config.artifact }}
         if-no-files-found: error
 
+  msvc-check:
+    name: MSVC ${{ matrix.arch }} compilation check
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, x86]
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: ${{ matrix.arch }}
+
+    - name: Compile all sources with cl.exe
+      shell: cmd
+      run: |
+        cl.exe /c /W3 /O2 /DNDEBUG /D_CRT_SECURE_NO_DEPRECATE ^
+          /I. /Isrc /Isrc\m68000 /Ilibretro-common\include ^
+          /D__LIBRETRO__ /DINLINE="_inline" ^
+          libretro.c ^
+          src\blitter.c src\dac.c src\dsp.c src\file.c ^
+          src\gpu.c src\jaguar.c src\jerry.c src\tom.c src\op.c ^
+          src\cdintf.c src\cdrom.c src\crc32.c src\event.c ^
+          src\eeprom.c src\filedb.c src\joystick.c src\settings.c ^
+          src\memtrack.c src\mmu.c src\vjag_memory.c ^
+          src\universalhdr.c src\wavetable.c ^
+          src\jagbios.c src\jagbios2.c ^
+          src\jagcdbios.c src\jagdevcdbios.c ^
+          src\jagstub1bios.c src\jagstub2bios.c ^
+          src\m68000\m68kinterface.c ^
+          src\blitter_simd_scalar.c ^
+          src\blitter_simd_sse2.c
+        echo MSVC compilation check passed
+
+  vita-build:
+    name: build-PS Vita
+    runs-on: ubuntu-latest
+    container:
+      image: vitasdk/vitasdk:latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build
+      run: make -j4 platform=vita
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: PS Vita
+        path: virtualjaguar_libretro_vita.a
+        if-no-files-found: error
+
+  switch-build:
+    name: build-Nintendo Switch
+    runs-on: ubuntu-latest
+    container:
+      image: devkitpro/devkita64:latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build
+      run: make -j4 platform=libnx
+      env:
+        DEVKITPRO: /opt/devkitpro
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: Nintendo Switch
+        path: virtualjaguar_libretro_libnx.a
+        if-no-files-found: error
+
   c89-lint:
     name: C89 compliance check
     runs-on: ubuntu-latest
@@ -191,10 +280,9 @@ jobs:
       run: |
         echo "==> Checking C89 compliance (catches MSVC C89 errors)..."
         FAILED=0
-        for f in libretro.c src/*.c; do
-          # Skip machine-generated files
+        for f in libretro.c src/*.c src/m68000/m68kinterface.c; do
           case "$f" in
-            src/m68000/*|src/jag*bios*.c|src/jagstub*bios.c|src/blitter_simd_neon.c|src/blitter_simd_sse2.c) continue ;;
+            src/m68000/cpu*.c|src/m68000/read*.c|src/jag*bios*.c|src/jagstub*bios.c|src/blitter_simd_neon.c|src/blitter_simd_sse2.c) continue ;;
           esac
           if ! gcc -fsyntax-only -std=gnu89 \
               -Werror=declaration-after-statement \
@@ -209,3 +297,21 @@ jobs:
           exit 1
         fi
         echo "==> All files pass C89 declaration check"
+
+    - name: Check for stdbool.h usage (use boolean.h instead)
+      run: |
+        echo "==> Checking for direct stdbool.h includes..."
+        FAILED=0
+        for f in libretro.c src/*.c src/*.h; do
+          case "$f" in
+            src/boolean.h) continue ;;
+          esac
+          if grep -n '#include.*<stdbool\.h>' "$f" 2>/dev/null; then
+            echo "::error file=$f::Use <boolean.h> instead of <stdbool.h> (MSVC 2005/2010 compat)"
+            FAILED=1
+          fi
+        done
+        if [ "$FAILED" = "1" ]; then
+          exit 1
+        fi
+        echo "==> No direct stdbool.h includes found"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,12 @@ jobs:
             cc: clang
             cxx: clang++
 
+          - platform: macos-x86_64
+            artifact: virtualjaguar_libretro.dylib
+            os: macos-13
+            cc: clang
+            cxx: clang++
+
           # Windows
           - platform: windows-x86_64
             artifact: virtualjaguar_libretro.dll
@@ -78,13 +84,24 @@ jobs:
             android: true
             android_abi: 'armeabi-v7a'
 
-          # iOS
+          - platform: android-x86_64
+            artifact: libs/x86_64/libretro.so
+            os: ubuntu-latest
+            android: true
+            android_abi: 'x86_64'
+
+          - platform: android-x86
+            artifact: libs/x86/libretro.so
+            os: ubuntu-latest
+            android: true
+            android_abi: 'x86'
+
+          # iOS / tvOS
           - platform: ios-arm64
             artifact: virtualjaguar_libretro_ios.dylib
             os: macos-latest
             make_platform: 'ios-arm64'
 
-          # tvOS
           - platform: tvos-arm64
             artifact: virtualjaguar_libretro_tvos.dylib
             os: macos-latest
@@ -156,8 +173,56 @@ jobs:
         path: dist/
         if-no-files-found: error
 
+  vita-build:
+    name: build-vita
+    runs-on: ubuntu-latest
+    container:
+      image: vitasdk/vitasdk:latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build
+      run: make -j4 platform=vita
+
+    - name: Package
+      run: |
+        mkdir -p dist
+        cp virtualjaguar_libretro_vita.a dist/virtualjaguar_libretro-vita.a
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: virtualjaguar_libretro-vita
+        path: dist/
+        if-no-files-found: error
+
+  switch-build:
+    name: build-switch
+    runs-on: ubuntu-latest
+    container:
+      image: devkitpro/devkita64:latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build
+      run: make -j4 platform=libnx
+      env:
+        DEVKITPRO: /opt/devkitpro
+
+    - name: Package
+      run: |
+        mkdir -p dist
+        cp virtualjaguar_libretro_libnx.a dist/virtualjaguar_libretro-switch.a
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: virtualjaguar_libretro-switch
+        path: dist/
+        if-no-files-found: error
+
   release:
-    needs: build
+    needs: [build, vita-build, switch-build]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          # Linux
           - platform: linux-x86_64
             artifact: virtualjaguar_libretro.so
             os: ubuntu-latest
@@ -25,18 +26,69 @@ jobs:
             cc: gcc
             cxx: g++
 
+          - platform: linux-i686
+            artifact: virtualjaguar_libretro.so
+            os: ubuntu-latest
+            cc: 'gcc -m32'
+            cxx: 'g++ -m32'
+            multilib: true
+
+          # macOS
           - platform: macos-arm64
             artifact: virtualjaguar_libretro.dylib
             os: macos-latest
             cc: clang
             cxx: clang++
 
+          # Windows
           - platform: windows-x86_64
             artifact: virtualjaguar_libretro.dll
             os: windows-latest
             cc: gcc
             cxx: g++
             shell: 'msys2 {0}'
+            msystem: 'MINGW64'
+            msys2_packages: 'mingw-w64-x86_64-gcc make'
+
+          - platform: windows-i686
+            artifact: virtualjaguar_libretro.dll
+            os: windows-latest
+            cc: gcc
+            cxx: g++
+            shell: 'msys2 {0}'
+            msystem: 'MINGW32'
+            msys2_packages: 'mingw-w64-i686-gcc make'
+
+          # Emscripten (WebAssembly)
+          - platform: emscripten-wasm
+            artifact: virtualjaguar_libretro_emscripten.bc
+            os: ubuntu-latest
+            emscripten: true
+
+          # Android NDK
+          - platform: android-arm64-v8a
+            artifact: libs/arm64-v8a/libretro.so
+            os: ubuntu-latest
+            android: true
+            android_abi: 'arm64-v8a'
+
+          - platform: android-armeabi-v7a
+            artifact: libs/armeabi-v7a/libretro.so
+            os: ubuntu-latest
+            android: true
+            android_abi: 'armeabi-v7a'
+
+          # iOS
+          - platform: ios-arm64
+            artifact: virtualjaguar_libretro_ios.dylib
+            os: macos-latest
+            make_platform: 'ios-arm64'
+
+          # tvOS
+          - platform: tvos-arm64
+            artifact: virtualjaguar_libretro_tvos.dylib
+            os: macos-latest
+            make_platform: 'tvos-arm64'
 
     name: build-${{ matrix.config.platform }}
     runs-on: ${{ matrix.config.os }}
@@ -48,25 +100,54 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install multilib
+      if: matrix.config.multilib
+      run: |
+        sudo dpkg --add-architecture i386
+        sudo apt-get update
+        sudo apt-get install -y gcc-multilib g++-multilib
+
     - name: Set up MSYS2
       if: runner.os == 'Windows'
       uses: msys2/setup-msys2@v2
       with:
-        msystem: MINGW64
+        msystem: ${{ matrix.config.msystem || 'MINGW64' }}
         update: false
-        install: >-
-          mingw-w64-x86_64-gcc
-          make
+        install: ${{ matrix.config.msys2_packages || 'mingw-w64-x86_64-gcc make' }}
+
+    - name: Set up Emscripten
+      if: matrix.config.emscripten
+      uses: mymindstorm/setup-emsdk@v14
+
+    - name: Set up Android NDK
+      if: matrix.config.android
+      uses: nttld/setup-ndk@v1
+      id: setup-ndk
+      with:
+        ndk-version: r26d
 
     - name: Build
-      run: make -j4 CC=${{ matrix.config.cc }} CXX=${{ matrix.config.cxx }}
+      if: ${{ !matrix.config.emscripten && !matrix.config.android && !matrix.config.make_platform }}
+      run: make -j4 CC="${{ matrix.config.cc }}" CXX="${{ matrix.config.cxx }}"
+
+    - name: Build (platform)
+      if: matrix.config.make_platform
+      run: make -j4 platform=${{ matrix.config.make_platform }}
+
+    - name: Build (Emscripten)
+      if: matrix.config.emscripten
+      run: emmake make -j4 platform=emscripten
+
+    - name: Build (Android NDK)
+      if: matrix.config.android
+      run: |
+        ${{ steps.setup-ndk.outputs.ndk-path }}/ndk-build \
+          APP_ABI=${{ matrix.config.android_abi }} -j4
 
     - name: Package
       run: |
         mkdir -p dist
-        cp ${{ matrix.config.artifact }} dist/virtualjaguar_libretro-${{ matrix.config.platform }}${SUFFIX}
-      env:
-        SUFFIX: ${{ matrix.config.platform == 'windows-x86_64' && '.dll' || (matrix.config.platform == 'macos-arm64' && '.dylib' || '.so') }}
+        cp ${{ matrix.config.artifact }} dist/virtualjaguar_libretro-${{ matrix.config.platform }}$(echo "${{ matrix.config.artifact }}" | grep -o '\.[^.]*$')
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4
@@ -91,7 +172,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         TAG="${GITHUB_REF_NAME}"
-        # Collect all built binaries
+        echo "==> Creating release ${TAG} with artifacts:"
         find artifacts/ -type f | sort
 
         gh release create "${TAG}" \

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,77 @@
+name: Bump Version & Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      dry_run:
+        description: 'Dry run (no commit/tag/push)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Parse current version
+      id: current
+      run: |
+        VER=$(grep -oP 'library_version\s*=\s*"v\K[0-9]+\.[0-9]+\.[0-9]+' libretro.c)
+        echo "version=${VER}" >> "$GITHUB_OUTPUT"
+        echo "Current version: v${VER}"
+
+    - name: Compute next version
+      id: next
+      run: |
+        IFS='.' read -r MAJOR MINOR PATCH <<< "${{ steps.current.outputs.version }}"
+        case "${{ inputs.bump }}" in
+          major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+          minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+          patch) PATCH=$((PATCH + 1)) ;;
+        esac
+        NEXT="${MAJOR}.${MINOR}.${PATCH}"
+        echo "version=${NEXT}" >> "$GITHUB_OUTPUT"
+        echo "Next version: v${NEXT}"
+
+    - name: Update libretro.c
+      run: |
+        sed -i 's/library_version  = "v${{ steps.current.outputs.version }}"/library_version  = "v${{ steps.next.outputs.version }}"/' libretro.c
+        grep 'library_version' libretro.c
+
+    - name: Commit, tag, and push
+      if: ${{ !inputs.dry_run }}
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add libretro.c
+        git commit -m "Bump version to v${{ steps.next.outputs.version }}"
+        git tag "v${{ steps.next.outputs.version }}"
+        git push origin HEAD --tags
+
+    - name: Summary
+      run: |
+        echo "### Version Bump" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **From:** v${{ steps.current.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **To:** v${{ steps.next.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **Bump:** ${{ inputs.bump }}" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **Dry run:** ${{ inputs.dry_run }}" >> "$GITHUB_STEP_SUMMARY"
+        if [ "${{ inputs.dry_run }}" = "false" ]; then
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Tag \`v${{ steps.next.outputs.version }}\` pushed — Release workflow will create the GitHub Release automatically." >> "$GITHUB_STEP_SUMMARY"
+        fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Local E2E test build (downloads rcheevos tarball)
+/build/
+
+# Legacy local path (older CI recipe); keep ignored if present
+/test_memory_map
+
 # Build artifacts
 *.o
 *.so
@@ -26,6 +32,8 @@ test/test_*
 !test/test_*.c
 !test/test_*.sh
 !test/test_*.py
+test/tools/test_memory_map
+test/tools/sram_test
 test/dump_caller
 test/dump_pc
 test/heap_search

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Build artifacts
 *.o
 *.so
 *.dll
@@ -5,7 +6,43 @@
 *.exe
 *.js
 *.bc
+
+# macOS
 .DS_Store
 .build
+
+# IDE / editor
 /.claude
+/.cursor
+/.vscode
+
+# Python virtual environments
+.venv*/
+
+# Test binaries and debug artifacts
 test/test_blitter_simd
+test/test_blitter_scalar
+test/test_*
+!test/test_*.c
+!test/test_*.sh
+!test/test_*.py
+test/dump_caller
+test/dump_pc
+test/heap_search
+test/*.dSYM/
+
+# Test logs
+*.log
+test/*.log
+
+# Test ROMs (keep source scripts, ignore binaries)
+test/roms/*.jag
+test/roms/*.rom
+test/roms/private/
+
+# Reference docs (large PDFs, not source)
+docs/atari-jaguar-1999/
+
+# LLDB scripts (local debug helpers)
+test/lldb_*.cmd
+test/lldb_*.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,6 +80,10 @@ include:
     file: '/tvos-arm64.yml'
 
   #################################### MISC ##################################
+  # Emscripten (WebAssembly)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/emscripten-static.yml'
+
   # webOS 32-bit (LGTV)
   - project: 'libretro-infrastructure/ci-templates'
     file: '/webos-make.yml'
@@ -212,6 +216,12 @@ libretro-build-libnx-aarch64:
     - .core-defs
 
 #################################### MISC ####################################
+# Emscripten (WebAssembly)
+libretro-build-emscripten:
+  extends:
+    - .libretro-emscripten-static-retroarch-master
+    - .core-defs
+
 # webOS 32-bit
 libretro-build-webos-armv7a:
   extends:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ Key docs:
 ### Testing
 
 See `docs/test-infrastructure.md` for all test harnesses:
+- `test/test_dsp_mac40.c` — Jaguar DSP **40-bit MAC** accumulator semantics (`dsp_acc40.h`), run in CI with SIMD tests; relevant for long IIR chains (e.g. pink-noise generators on DSP).
 - `test/headless.py` — Python headless runner via libretro.py (screenshots, frame control)
 - `test/regression_test.sh` — screenshot regression suite with baseline comparison
 - `test/test_cd_boot.c` — low-level C harness with dlsym access to 68K registers and RAM

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,12 +92,27 @@ Key docs:
 
 ### Testing
 
+RetroAchievements-related — **no RetroAchievements account, API, or gameplay server**; local validation only. The E2E harness still **fetches the pinned rcheevos source tarball from GitHub** when `build/rcheevos-static` is missing (CI may cache that directory); that is unrelated to contacting RetroAchievements services.
+
+- `test/tools/test_memory_map.c` — asserts `SET_MEMORY_MAPS`, `SET_SUPPORT_ACHIEVEMENTS` with **`true`**, and descriptor layout vs `retro_get_memory_data(SYSTEM_RAM)`.
+- `test/tools/test_rcheevos_e2e.sh` — downloads pinned **rcheevos** (`RCHEEVOS_REF`) when needed, builds `librcheevos.a`, then runs `test_rcheevos_e2e` to verify **rc_libretro** memory resolution (`RC_CONSOLE_ATARI_JAGUAR`) matches host RAM — the same mapping stack RetroArch uses before any RA cloud call.
+
 See `docs/test-infrastructure.md` for all test harnesses:
 - `test/test_dsp_mac40.c` — Jaguar DSP **40-bit MAC** accumulator semantics (`dsp_acc40.h`), run in CI with SIMD tests; relevant for long IIR chains (e.g. pink-noise generators on DSP).
 - `test/headless.py` — Python headless runner via libretro.py (screenshots, frame control)
 - `test/regression_test.sh` — screenshot regression suite with baseline comparison
 - `test/test_cd_boot.c` — low-level C harness with dlsym access to 68K registers and RAM
 - `test/sram_test.sh` — SRAM interface round-trip testing
+
+#### Headless framebuffer / 240p suite — how to report issues
+
+Profiling symbols like **`__muldi3`** (64-bit multiply helpers on some 32-bit ABIs) are a **compiler/performance** concern, **not** evidence that the Jaguar 240p test ROM’s DSP pink-noise path or NTSC timing is wrong. Do **not** frame “240p fails” primarily as a **`__muldi3`** bug unless you are optimizing a 32-bit build for speed.
+
+The **useful** regression story for automated screenshot / libretro.py / SessionBuilder runs is:
+
+- **Symptom:** On some cores or builds, a **non-RetroArch headless session** does not expose the **same composited framebuffer** via the libretro API (`video_screenshot`, etc.) as **RetroArch with the same core binary** — e.g. main menu of **jag_240p_test_suite v1.0.0** shows only a **thin band** (~order of **1k** non-black RGB pixels) vs **tens of thousands** on a known-good path.
+- **Interpretation:** Suspect **presentation / pixel source** — Object Processor and blitter output vs **what headless clients actually read** — until disproven with hardware or reference captures. This is **not** “prove 240p timing is wrong first.”
+- **Checks:** Use in-repo gates (e.g. **screenshots-preflight** / main-menu sanity, non-black pixel floor on the **~2000+** scale). Passing preflight ⇒ the **headless read-path** issue is resolved for that artifact; failing preflight ⇒ file a **framebuffer/compositing** bug for **headless libretro** consumption (logs, **two artifacts**: broken vs good), not a long **`__muldi3`** narrative.
 
 ### Known Limitations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,27 @@ Output binary name varies by platform:
 - Linux: `virtualjaguar_libretro.so`
 - Windows: `virtualjaguar_libretro.dll`
 
-There is no test suite. CI runs `make -j4` on Ubuntu (GCC) and macOS (Clang).
+CI runs `make -j4` on Ubuntu (GCC) and macOS (Clang), plus screenshot regression tests via `test/regression_test.sh`. See `docs/test-infrastructure.md` for the full test harness inventory.
 
 ## Architecture
+
+### C Language Standard — C89/GNU89
+
+This codebase **must** compile as C89 (GNU89 dialect). The libretro buildbot uses MSVC on Windows, which enforces C89 strictly. CI includes a `c89-lint` job that catches violations.
+
+**Rules:**
+- **No mid-block variable declarations.** All variables must be declared at the top of their enclosing block (function or `{}`), before any statements. This is the most common violation.
+- `//` comments are allowed (GNU89 extension), but `/* */` is preferred for new code.
+- No C99 features: no `for (int i = ...)`, no compound literals, no designated initializers, no VLAs.
+- SIMD files (`src/blitter_simd_sse2.c`, `src/blitter_simd_neon.c`) are exempt from the lint check since they require platform-specific headers.
+- Machine-generated files (`src/m68000/*`) are also exempt.
+
+**Local check before pushing:**
+```bash
+gcc -fsyntax-only -std=gnu89 -Werror=declaration-after-statement \
+    -I. -Isrc -Isrc/m68000 -Ilibretro-common/include \
+    -D__LIBRETRO__ -DINLINE="inline" src/YOURFILE.c
+```
 
 ### Atari Jaguar Hardware Emulation
 
@@ -56,11 +74,29 @@ Core options defined in `libretro_core_options.h` control blitter mode, BIOS usa
 - `src/` — emulator core (hardware chips, CPU, I/O, BIOS ROMs as C arrays)
 - `src/m68000/` — UAE-derived 68K CPU emulation
 - `libretro-common/` — shared libretro utility library (string, file, VFS)
-- `docs/` — original Virtual Jaguar documentation, changelog, known issues
+- `docs/` — documentation: changelog, known issues, BUTCH register map, CD data flow, test infrastructure
+- `test/tools` — test scripts and headless front-ends
+- `test/roms` — test ROMs; `private/` subdirectory has commercial ROMs and BIOSes
 
 ### Build System
 
 `Makefile` handles 30+ platform targets with auto-detection. `Makefile.common` lists all source files. Platform is selected via `platform=` variable or auto-detected from `uname`. Key flags: `-D__LIBRETRO__`, `-DMSB_FIRST` for big-endian platforms.
+
+### Jaguar CD Emulation
+
+CD support is implemented across `src/cdrom.c` (BUTCH chip / FIFO / DSA commands), `src/cdintf.c` (disc image loading: CUE/BIN, CHD, CDI), and hooks in `src/jaguar.c` (BIOS auth bypass, boot stub injection).
+
+Key docs:
+- `docs/butch-registers.md` — full BUTCH register map ($DFFF00-$DFFF2F) with bit definitions
+- `docs/cd-data-flow.md` — how CD data moves from disc to RAM (I2S -> FIFO -> GPU ISR -> RAM), BIOS code map, boot stub layout
+
+### Testing
+
+See `docs/test-infrastructure.md` for all test harnesses:
+- `test/headless.py` — Python headless runner via libretro.py (screenshots, frame control)
+- `test/regression_test.sh` — screenshot regression suite with baseline comparison
+- `test/test_cd_boot.c` — low-level C harness with dlsym access to 68K registers and RAM
+- `test/sram_test.sh` — SRAM interface round-trip testing
 
 ### Known Limitations
 

--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,6 @@ else ifeq ($(platform), emscripten)
 	AR = emar
 	STATIC_LINKING = 1
 	FLAGS += -DHAVE_EMSCRIPTEN
-	CFLAGS += -O2
 
 # Windows MSVC 2017 all architectures
 else ifneq (,$(findstring windows_msvc2017,$(platform)))

--- a/Makefile
+++ b/Makefile
@@ -614,9 +614,25 @@ else
 endif
 
 clean:
-	rm -f $(TARGET) $(OBJECTS)
+	rm -f $(TARGET) $(OBJECTS) test/test_cheat
 
-.PHONY: clean
+# Self-contained unit tests (parser + list management + simulated
+# memory application). Does not require a ROM or a working build of
+# the full core.
+ifneq (,$(findstring msvc,$(platform)))
+test:
+	@echo "make test requires GCC/Clang flags; use MSYS2/Unix or compile test/test_cheat.c manually."
+	@false
+else
+test: test/test_cheat
+	./test/test_cheat
+
+test/test_cheat: test/test_cheat.c src/cheat.c src/cheat.h
+	$(CC) -O2 -Wall -std=c99 -I src -I libretro-common/include \
+		-o $@ test/test_cheat.c src/cheat.c
+endif
+
+.PHONY: clean test
 endif
 
 print-%:

--- a/Makefile
+++ b/Makefile
@@ -237,9 +237,15 @@ else ifeq ($(platform), switch)
 	STATIC_LINKING=1
 	fpic := -nostdlib
 
-# emscripten
+# emscripten (WebAssembly / asm.js for RetroArch Web Player)
 else ifeq ($(platform), emscripten)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).bc
+	CC = emcc
+	CXX = em++
+	AR = emar
+	STATIC_LINKING = 1
+	FLAGS += -DHAVE_EMSCRIPTEN
+	CFLAGS += -O2
 
 # Windows MSVC 2017 all architectures
 else ifneq (,$(findstring windows_msvc2017,$(platform)))

--- a/Makefile.common
+++ b/Makefile.common
@@ -92,30 +92,21 @@ endif
 ifneq (,$(filter MINGW64% MINGW32%,$(MSYSTEM)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
 endif
-# 32-bit x86 needs explicit -msse2 (x86_64 has it baseline).
-# Skip for MSVC (cl.exe) — it enables SSE2 by default on x86 and does
-# not understand the GCC -msse2 flag.
-ifeq ($(BLITTER_SIMD_SRC),$(CORE_DIR)/src/blitter_simd_sse2.c)
-ifeq (,$(findstring msvc,$(platform)))
-ifneq (,$(filter i686 i386 x86 win32,$(ARCH) $(platform)))
-   CFLAGS += -msse2
-endif
-ifneq (,$(filter MINGW32%,$(MSYSTEM)))
-   CFLAGS += -msse2
-endif
-endif
-endif
 
 # Native build fallback: auto-detect from host architecture, but only for
 # native-build platforms (unix/osx/win). Cross-compile targets (vita, ps3,
 # libnx, etc.) set platform explicitly and should not use host detection.
+# Also skip when CC looks like a cross-compiler (e.g. arm-webos-linux-gnueabi-gcc).
+BLITTER_CROSS_CC := $(findstring arm-,$(CC))$(findstring aarch64-,$(CC))$(findstring mips,$(CC))$(findstring powerpc,$(CC))
 ifeq ($(BLITTER_SIMD_SRC),)
+ifeq ($(BLITTER_CROSS_CC),)
 ifneq (,$(filter unix osx win,$(platform)))
 ifneq (,$(filter x86_64 i686 i386,$(shell uname -m 2>/dev/null)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
 endif
 ifneq (,$(filter aarch64 arm64,$(shell uname -m 2>/dev/null)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_neon.c
+endif
 endif
 endif
 endif
@@ -127,6 +118,14 @@ ifeq ($(BLITTER_SIMD_SRC),)
 endif
 
 SOURCES_C += $(BLITTER_SIMD_SRC)
+
+# Add -msse2 flag for all GCC/Clang SSE2 builds. No-op on x86_64 (baseline),
+# required on i686 / gcc -m32. Skip for MSVC (uses /arch:SSE2, not -msse2).
+ifeq ($(BLITTER_SIMD_SRC),$(CORE_DIR)/src/blitter_simd_sse2.c)
+ifeq (,$(findstring msvc,$(platform)))
+   CFLAGS += -msse2
+endif
+endif
 
 ifneq ($(STATIC_LINKING), 1)
 SOURCES_C += \

--- a/Makefile.common
+++ b/Makefile.common
@@ -93,12 +93,16 @@ ifneq (,$(filter MINGW64% MINGW32%,$(MSYSTEM)))
    BLITTER_SIMD_SRC := $(CORE_DIR)/src/blitter_simd_sse2.c
 endif
 # 32-bit x86 needs explicit -msse2 (x86_64 has it baseline).
+# Skip for MSVC (cl.exe) — it enables SSE2 by default on x86 and does
+# not understand the GCC -msse2 flag.
 ifeq ($(BLITTER_SIMD_SRC),$(CORE_DIR)/src/blitter_simd_sse2.c)
+ifeq (,$(findstring msvc,$(platform)))
 ifneq (,$(filter i686 i386 x86 win32,$(ARCH) $(platform)))
    CFLAGS += -msse2
 endif
 ifneq (,$(filter MINGW32%,$(MSYSTEM)))
    CFLAGS += -msse2
+endif
 endif
 endif
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -24,6 +24,7 @@ SOURCES_C :=  \
 	$(CORE_DIR)/src/tom.c  \
 	$(CORE_DIR)/src/cdintf.c \
 	$(CORE_DIR)/src/cdrom.c \
+	$(CORE_DIR)/src/cheat.c \
 	$(CORE_DIR)/src/crc32.c \
 	$(CORE_DIR)/src/event.c \
 	$(CORE_DIR)/src/eeprom.c \

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,6 +1,6 @@
-LOCAL_PATH := $(call my-dir)
+LOCAL_PATH := $(call my-dir)/..
 
-CORE_DIR := $(LOCAL_PATH)/..
+CORE_DIR := $(LOCAL_PATH)
 
 include $(CORE_DIR)/Makefile.common
 

--- a/libretro.c
+++ b/libretro.c
@@ -781,6 +781,8 @@ bool retro_serialize(void *data, size_t size)
    uint8_t *buf, *start;
    size_t written;
    uint32_t magic, version, flags, reserved;
+   extern uint8_t jerry_ram_8[];
+   extern bool lowerField;
 
    if (!data || size < STATE_SIZE)
       return false;
@@ -802,11 +804,9 @@ bool retro_serialize(void *data, size_t size)
    STATE_SAVE_BUF(buf, jaguarMainRAM, 0x200000);  /* 2 MB main RAM */
    STATE_SAVE_BUF(buf, tomRam8, 0x4000);           /* 16 KB TOM registers */
 
-   extern uint8_t jerry_ram_8[];
    STATE_SAVE_BUF(buf, jerry_ram_8, 0x10000);      /* 64 KB JERRY registers */
 
    /* Jaguar misc state */
-   extern bool lowerField;
    STATE_SAVE_VAR(buf, lowerField);
 
    /* Module state */
@@ -838,6 +838,8 @@ bool retro_unserialize(const void *data, size_t size)
 {
    const uint8_t *buf;
    uint32_t magic, version, flags, reserved;
+   extern uint8_t jerry_ram_8[];
+   extern bool lowerField;
 
    if (!data || size < STATE_SIZE)
       return false;
@@ -857,11 +859,9 @@ bool retro_unserialize(const void *data, size_t size)
    STATE_LOAD_BUF(buf, jaguarMainRAM, 0x200000);
    STATE_LOAD_BUF(buf, tomRam8, 0x4000);
 
-   extern uint8_t jerry_ram_8[];
    STATE_LOAD_BUF(buf, jerry_ram_8, 0x10000);
 
    /* Jaguar misc state */
-   extern bool lowerField;
    STATE_LOAD_VAR(buf, lowerField);
 
    /* Module state */

--- a/libretro.c
+++ b/libretro.c
@@ -8,6 +8,7 @@
 #include <compat/posix_string.h>
 #include <compat/strl.h>
 
+#include "cheat.h"
 #include "file.h"
 #include "jagbios.h"
 #include "jagbios2.h"
@@ -51,6 +52,7 @@ static retro_video_refresh_t video_cb;
 static retro_input_poll_t input_poll_cb;
 static retro_input_state_t input_state_cb;
 static retro_environment_t environ_cb;
+static retro_log_printf_t libretro_log_printf;
 retro_audio_sample_batch_t audio_batch_cb;
 
 static bool libretro_supports_bitmasks = false;
@@ -291,8 +293,15 @@ void retro_set_environment(retro_environment_t cb)
 {
    struct retro_vfs_interface_info vfs_iface_info;
    struct retro_core_options_update_display_callback update_display_cb;
+   struct retro_log_callback logging;
    bool option_categories = false;
    environ_cb = cb;
+
+   logging.log = NULL;
+   if (cb(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &logging))
+      libretro_log_printf = logging.log;
+   else
+      libretro_log_printf = NULL;
 
    libretro_set_core_options(environ_cb, &option_categories);
    update_display_cb.callback = update_option_visibility;
@@ -881,14 +890,44 @@ bool retro_unserialize(const void *data, size_t size)
    return true;
 }
 
+/* Cheat codes — the parser and list management live in src/cheat.c so
+ * they can be unit-tested without the rest of the emulator. Here we just
+ * bind them to the Jaguar memory bus and re-apply every frame so games
+ * that continuously overwrite the patched location are held to the
+ * cheat value. */
+static cheat_list_t cheat_list;
+
+static void cheat_write_jaguar(uint32_t addr, uint32_t value,
+                               uint8_t size, void *user)
+{
+   (void)user;
+   switch (size)
+   {
+      case 1: JaguarWriteByte(addr, (uint8_t)value,  UNKNOWN); break;
+      case 2: JaguarWriteWord(addr, (uint16_t)value, UNKNOWN); break;
+      case 4: JaguarWriteLong(addr, value,           UNKNOWN); break;
+      default:
+         if (libretro_log_printf)
+            libretro_log_printf(RETRO_LOG_WARN,
+               "[Virtual Jaguar] cheat: unsupported write size %u at 0x%06X\n",
+               (unsigned)size, (unsigned)(addr & 0xFFFFFFU));
+         break;
+   }
+}
+
 void retro_cheat_reset(void)
-{}
+{
+   cheat_list_reset(&cheat_list);
+}
 
 void retro_cheat_set(unsigned index, bool enabled, const char *code)
 {
-   (void)index;
-   (void)enabled;
-   (void)code;
+   cheat_list_set(&cheat_list, index, enabled, code);
+}
+
+static void cheat_apply_all(void)
+{
+   cheat_list_apply(&cheat_list, cheat_write_jaguar, NULL);
 }
 
 bool retro_load_game(const struct retro_game_info *info)
@@ -1012,6 +1051,7 @@ bool retro_load_game_special(unsigned game_type, const struct retro_game_info *i
 
 void retro_unload_game(void)
 {
+   retro_cheat_reset();
    JaguarDone();
    if (videoBuffer)
       free(videoBuffer);
@@ -1122,6 +1162,7 @@ void retro_run(void)
    update_input();
 
    JaguarExecuteNew();
+   cheat_apply_all();
    SoundCallback(NULL, sampleBuffer, vjs.hardwareTypeNTSC==1?BUFNTSC:BUFPAL);
 
    // Resolution changed

--- a/libretro.c
+++ b/libretro.c
@@ -295,6 +295,7 @@ void retro_set_environment(retro_environment_t cb)
    struct retro_core_options_update_display_callback update_display_cb;
    struct retro_log_callback logging;
    bool option_categories = false;
+   bool achievements = true;
    environ_cb = cb;
 
    logging.log = NULL;
@@ -311,6 +312,8 @@ void retro_set_environment(retro_environment_t cb)
    vfs_iface_info.iface                      = NULL;
    if (cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &vfs_iface_info))
       filestream_vfs_init(&vfs_iface_info);
+
+   environ_cb(RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS, &achievements);
 }
 
 static void check_variables(void)
@@ -1032,6 +1035,30 @@ bool retro_load_game(const struct retro_game_info *info)
    SET32(jaguarMainRAM, 0, 0x00200000);
    JaguarLoadFile((uint8_t*)info->data, info->size);
    JaguarReset();
+
+   /* Advertise the Jaguar memory map so frontends (RetroArch, etc.) can
+    * resolve emulated addresses to host buffers. Required for rcheevos.
+    *
+    * rcheevos defines one logical system-RAM region for RC_CONSOLE_ATARI_JAGUAR:
+    * $000000-$1FFFFF (see rcheevos consoleinfo). RetroAchievements addresses for
+    * Jaguar are authored in that space. GPU-style paths mirror 2 MiB within
+    * $000000-$7FFFFF in JaguarReadByte, but M68K direct access in this core is
+    * only linear $000000-$1FFFFF without those mirrors (m68k_read_memory_*). */
+   {
+      static struct retro_memory_descriptor descs[1];
+      static struct retro_memory_map memmap;
+
+      memset(descs, 0, sizeof(descs));
+      descs[0].flags     = RETRO_MEMDESC_SYSTEM_RAM | RETRO_MEMDESC_BIGENDIAN;
+      descs[0].ptr       = jaguarMainRAM;
+      descs[0].start     = 0x000000;
+      descs[0].len       = 0x200000;
+      descs[0].addrspace = "RAM";
+
+      memmap.descriptors     = descs;
+      memmap.num_descriptors = 1;
+      environ_cb(RETRO_ENVIRONMENT_SET_MEMORY_MAPS, &memmap);
+   }
 
    /* The frontend will load .srm data into our save buffer (returned by
     * retro_get_memory_data) after this function returns but before the

--- a/libretro.c
+++ b/libretro.c
@@ -19,6 +19,7 @@
 #include "settings.h"
 #include "tom.h"
 #include "state.h"
+#include "log.h"
 
 #define SAMPLERATE 48000
 #define BUFPAL  1920
@@ -52,8 +53,8 @@ static retro_video_refresh_t video_cb;
 static retro_input_poll_t input_poll_cb;
 static retro_input_state_t input_state_cb;
 static retro_environment_t environ_cb;
-static retro_log_printf_t libretro_log_printf;
 retro_audio_sample_batch_t audio_batch_cb;
+retro_log_printf_t vj_log_cb = NULL;
 
 static bool libretro_supports_bitmasks = false;
 static bool save_data_needs_unpack = false;
@@ -293,16 +294,18 @@ void retro_set_environment(retro_environment_t cb)
 {
    struct retro_vfs_interface_info vfs_iface_info;
    struct retro_core_options_update_display_callback update_display_cb;
-   struct retro_log_callback logging;
    bool option_categories = false;
    bool achievements = true;
    environ_cb = cb;
 
-   logging.log = NULL;
-   if (cb(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &logging))
-      libretro_log_printf = logging.log;
-   else
-      libretro_log_printf = NULL;
+   {
+      struct retro_log_callback log_iface;
+      log_iface.log = NULL;
+      if (cb(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &log_iface))
+         vj_log_cb = log_iface.log;
+      else
+         vj_log_cb = NULL;
+   }
 
    libretro_set_core_options(environ_cb, &option_categories);
    update_display_cb.callback = update_option_visibility;
@@ -910,9 +913,7 @@ static void cheat_write_jaguar(uint32_t addr, uint32_t value,
       case 2: JaguarWriteWord(addr, (uint16_t)value, UNKNOWN); break;
       case 4: JaguarWriteLong(addr, value,           UNKNOWN); break;
       default:
-         if (libretro_log_printf)
-            libretro_log_printf(RETRO_LOG_WARN,
-               "[Virtual Jaguar] cheat: unsupported write size %u at 0x%06X\n",
+         LOG_WRN("[Virtual Jaguar] cheat: unsupported write size %u at 0x%06X\n",
                (unsigned)size, (unsigned)(addr & 0xFFFFFFU));
          break;
    }
@@ -1035,6 +1036,13 @@ bool retro_load_game(const struct retro_game_info *info)
    SET32(jaguarMainRAM, 0, 0x00200000);
    JaguarLoadFile((uint8_t*)info->data, info->size);
    JaguarReset();
+
+   /* JaguarReset() randomizes RAM contents, which destroys RAM-loaded
+    * executables (ABS, COFF, JAGSERVER formats).  Cart ROMs are safe
+    * because they live at $800000+ which isn't touched by reset.
+    * Re-load the file so the program data is back in place. */
+   if (!jaguarCartInserted)
+      JaguarLoadFile((uint8_t*)info->data, info->size);
 
    /* Advertise the Jaguar memory map so frontends (RetroArch, etc.) can
     * resolve emulated addresses to host buffers. Required for rcheevos.

--- a/src/blitter_simd.h
+++ b/src/blitter_simd.h
@@ -13,7 +13,7 @@
 #define BLITTER_SIMD_H
 
 #include <stdint.h>
-#include <stdbool.h>
+#include <boolean.h>
 
 typedef struct
 {

--- a/src/blitter_simd_sse2.c
+++ b/src/blitter_simd_sse2.c
@@ -12,9 +12,16 @@
 #include <emmintrin.h>  /* SSE2 */
 #include <string.h>     /* memcpy for type-punning extract */
 
-/* _mm_cvtsi128_si64 only exists on x86_64 (needs 64-bit GP register).
- * memcpy from the __m128i is portable, alignment-safe, and compilers
- * optimize it to a single register move. */
+/* _mm_set_epi64x doesn't exist in MSVC 2010 and earlier.
+ * Build from two 32-bit halves instead (pure SSE2). */
+#if defined(_MSC_VER) && _MSC_VER < 1700
+#define SSE2_SET64(hi, lo) \
+   _mm_set_epi32((int)((uint64_t)(hi) >> 32), (int)(hi), \
+                 (int)((uint64_t)(lo) >> 32), (int)(lo))
+#else
+#define SSE2_SET64(hi, lo) _mm_set_epi64x((int64_t)(hi), (int64_t)(lo))
+#endif
+
 static uint64_t sse2_extract_u64(__m128i v)
 {
    uint64_t r;
@@ -35,15 +42,15 @@ static uint64_t sse2_lfu(uint64_t srcd, uint64_t dstd, uint8_t lfu_func)
    uint64_t func2 = (lfu_func & 0x04) ? 0xFFFFFFFFFFFFFFFFULL : 0;
    uint64_t func3 = (lfu_func & 0x08) ? 0xFFFFFFFFFFFFFFFFULL : 0;
 
-   __m128i vs   = _mm_set_epi64x(0, (int64_t)srcd);
-   __m128i vd   = _mm_set_epi64x(0, (int64_t)dstd);
+   __m128i vs   = SSE2_SET64(0, srcd);
+   __m128i vd   = SSE2_SET64(0, dstd);
    __m128i vns  = _mm_andnot_si128(vs, _mm_set1_epi32(-1)); /* ~srcd */
    __m128i vnd  = _mm_andnot_si128(vd, _mm_set1_epi32(-1)); /* ~dstd */
 
-   __m128i vf0  = _mm_set_epi64x(0, (int64_t)func0);
-   __m128i vf1  = _mm_set_epi64x(0, (int64_t)func1);
-   __m128i vf2  = _mm_set_epi64x(0, (int64_t)func2);
-   __m128i vf3  = _mm_set_epi64x(0, (int64_t)func3);
+   __m128i vf0  = SSE2_SET64(0, func0);
+   __m128i vf1  = SSE2_SET64(0, func1);
+   __m128i vf2  = SSE2_SET64(0, func2);
+   __m128i vf3  = SSE2_SET64(0, func3);
 
    /* (~s & ~d & f0) | (~s & d & f1) | (s & ~d & f2) | (s & d & f3) */
    __m128i t0 = _mm_and_si128(_mm_and_si128(vns, vnd), vf0);
@@ -64,8 +71,8 @@ static uint64_t sse2_lfu(uint64_t srcd, uint64_t dstd, uint8_t lfu_func)
 static uint8_t sse2_dcomp(uint64_t patd, uint64_t srcd, uint64_t dstd, bool cmpdst)
 {
    uint64_t other = cmpdst ? dstd : srcd;
-   __m128i vp = _mm_set_epi64x(0, (int64_t)patd);
-   __m128i vo = _mm_set_epi64x(0, (int64_t)other);
+   __m128i vp = SSE2_SET64(0, patd);
+   __m128i vo = SSE2_SET64(0, other);
    __m128i vxor = _mm_xor_si128(vp, vo);
 
    /* Compare each byte against zero */
@@ -88,8 +95,8 @@ static uint8_t sse2_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
    uint8_t result = 0;
    uint8_t packed = 0;
 
-   __m128i vs = _mm_set_epi64x(0, (int64_t)srcz);
-   __m128i vd = _mm_set_epi64x(0, (int64_t)dstz);
+   __m128i vs = SSE2_SET64(0, srcz);
+   __m128i vd = SSE2_SET64(0, dstz);
 
    /* Bias for unsigned comparison via signed instructions */
    __m128i bias = _mm_set1_epi16((short)0x8000);
@@ -150,9 +157,9 @@ static uint64_t sse2_byte_merge(uint64_t src, uint64_t dst, uint16_t mask)
    sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 13) & 1))) << 48;
    sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 14) & 1))) << 56;
 
-   vmask = _mm_set_epi64x(0, (int64_t)sel64);
-   vsrc  = _mm_set_epi64x(0, (int64_t)src);
-   vdst  = _mm_set_epi64x(0, (int64_t)dst);
+   vmask = SSE2_SET64(0, sel64);
+   vsrc  = SSE2_SET64(0, src);
+   vdst  = SSE2_SET64(0, dst);
 
    /* result = (src & mask) | (dst & ~mask) */
    r = _mm_or_si128(

--- a/src/blitter_simd_sse2.c
+++ b/src/blitter_simd_sse2.c
@@ -10,6 +10,17 @@
 
 #include "blitter_simd.h"
 #include <emmintrin.h>  /* SSE2 */
+#include <string.h>     /* memcpy for type-punning extract */
+
+/* _mm_cvtsi128_si64 only exists on x86_64 (needs 64-bit GP register).
+ * memcpy from the __m128i is portable, alignment-safe, and compilers
+ * optimize it to a single register move. */
+static uint64_t sse2_extract_u64(__m128i v)
+{
+   uint64_t r;
+   memcpy(&r, &v, sizeof(r));
+   return r;
+}
 
 /* Logic Function Unit — SSE2
  *
@@ -41,7 +52,7 @@ static uint64_t sse2_lfu(uint64_t srcd, uint64_t dstd, uint8_t lfu_func)
    __m128i t3 = _mm_and_si128(_mm_and_si128(vs,  vd),  vf3);
 
    __m128i result = _mm_or_si128(_mm_or_si128(t0, t1), _mm_or_si128(t2, t3));
-   return (uint64_t)_mm_cvtsi128_si64(result);
+   return sse2_extract_u64(result);
 }
 
 /* Data Comparator — SSE2
@@ -75,6 +86,7 @@ static uint8_t sse2_dcomp(uint64_t patd, uint64_t srcd, uint64_t dstd, bool cmpd
 static uint8_t sse2_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
 {
    uint8_t result = 0;
+   uint8_t packed = 0;
 
    __m128i vs = _mm_set_epi64x(0, (int64_t)srcz);
    __m128i vd = _mm_set_epi64x(0, (int64_t)dstz);
@@ -107,7 +119,6 @@ static uint8_t sse2_zcomp(uint64_t srcz, uint64_t dstz, uint8_t zmode)
 
    /* movemask gives 2 bits per 16-bit lane (one per byte).
     * Convert to 1 bit per lane: lanes at positions 0,2,4,6 */
-   uint8_t packed = 0;
    if (result & 0x03) packed |= 0x01;  /* lane 0: bytes 0-1 */
    if (result & 0x0C) packed |= 0x02;  /* lane 1: bytes 2-3 */
    if (result & 0x30) packed |= 0x04;  /* lane 2: bytes 4-5 */
@@ -129,6 +140,8 @@ static uint64_t sse2_byte_merge(uint64_t src, uint64_t dst, uint16_t mask)
     * Bytes 1-7 = 0xFF or 0x00 from mask bits 8-14 (whole-byte select).
     * We expand each bit to a full 0xFF byte using sign-extension. */
    uint64_t sel64 = (uint64_t)(mask & 0xFF);  /* byte 0: per-bit */
+   __m128i vmask, vsrc, vdst, r;
+
    sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 8)  & 1))) << 8;
    sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 9)  & 1))) << 16;
    sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 10) & 1))) << 24;
@@ -137,17 +150,17 @@ static uint64_t sse2_byte_merge(uint64_t src, uint64_t dst, uint16_t mask)
    sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 13) & 1))) << 48;
    sel64 |= (uint64_t)((uint8_t)(-(int8_t)((mask >> 14) & 1))) << 56;
 
-   __m128i vmask = _mm_set_epi64x(0, (int64_t)sel64);
-   __m128i vsrc  = _mm_set_epi64x(0, (int64_t)src);
-   __m128i vdst  = _mm_set_epi64x(0, (int64_t)dst);
+   vmask = _mm_set_epi64x(0, (int64_t)sel64);
+   vsrc  = _mm_set_epi64x(0, (int64_t)src);
+   vdst  = _mm_set_epi64x(0, (int64_t)dst);
 
    /* result = (src & mask) | (dst & ~mask) */
-   __m128i r = _mm_or_si128(
+   r = _mm_or_si128(
       _mm_and_si128(vsrc, vmask),
       _mm_andnot_si128(vmask, vdst)
    );
 
-   return (uint64_t)_mm_cvtsi128_si64(r);
+   return sse2_extract_u64(r);
 }
 
 const blitter_simd_ops_t blitter_simd_ops = {

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -1,0 +1,306 @@
+#include <string.h>
+
+#include "cheat.h"
+
+static int hex_digit(char c)
+{
+   if (c >= '0' && c <= '9') return c - '0';
+   if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+   if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+   return -1;
+}
+
+/* Longest accepted form is 8 hex (addr) + 8 hex (value) after separator strip. */
+#define CHEAT_PARSE_MAX_HEX 16
+
+static bool hex_only_strip(const char *in, char *hex_out, size_t hex_max, size_t *n_hex)
+{
+   size_t n = 0;
+
+   for (; *in; in++)
+   {
+      if (hex_digit((char)*in) >= 0)
+      {
+         if (n >= hex_max - 1)
+            return false;
+         hex_out[n++] = (char)*in;
+      }
+      else if (*in != ' ' && *in != '\t' && *in != ':' &&
+               *in != '-' && *in != '.')
+         return false;
+   }
+   hex_out[n] = '\0';
+   *n_hex = n;
+   return true;
+}
+
+static bool has_ascii_ws(const char *s)
+{
+   for (; *s; s++)
+   {
+      if (*s == ' ' || *s == '\t')
+         return true;
+   }
+   return false;
+}
+
+/* Split on the last ':', '-', or '.' so "0000:3D00:FF" → address 00003D00 + value FF. */
+static bool split_last_cd_sep(const char *code,
+                              char *left, size_t lmax,
+                              char *right, size_t rmax)
+{
+   const char *last = NULL;
+   const char *p;
+   size_t ln;
+   size_t rn;
+
+   for (p = code; *p; p++)
+   {
+      if (*p == ':' || *p == '-' || *p == '.')
+         last = p;
+   }
+   if (!last || last == code || !last[1])
+      return false;
+
+   ln = (size_t)(last - code);
+   if (ln + 1 >= lmax)
+      return false;
+   memcpy(left, code, ln);
+   left[ln] = '\0';
+
+   for (p = last + 1, rn = 0; *p; p++)
+   {
+      if (rn + 1 >= rmax)
+         return false;
+      right[rn++] = *p;
+   }
+   right[rn] = '\0';
+   return ln > 0 && rn > 0;
+}
+
+static bool split_first_ws(const char *code,
+                           char *left, size_t lmax,
+                           char *right, size_t rmax)
+{
+   size_t ln = 0;
+   size_t rn = 0;
+   const char *p = code;
+
+   while (*p && *p != ' ' && *p != '\t')
+   {
+      if (ln + 1 >= lmax)
+         return false;
+      left[ln++] = *p++;
+   }
+   left[ln] = '\0';
+   if (*p == '\0')
+      return false;
+   while (*p == ' ' || *p == '\t')
+      p++;
+   if (*p == '\0')
+      return false;
+   while (*p)
+   {
+      if (rn + 1 >= rmax)
+         return false;
+      right[rn++] = *p++;
+   }
+   right[rn] = '\0';
+   return ln > 0 && rn > 0;
+}
+
+static bool pair_from_segment_lengths(size_t la, size_t lv,
+                                      size_t *addr_len, size_t *val_len)
+{
+   if (la == 6 && lv == 2) { *addr_len = 6; *val_len = 2; return true; }
+   if (la == 6 && lv == 4) { *addr_len = 6; *val_len = 4; return true; }
+   if (la == 8 && lv == 4) { *addr_len = 8; *val_len = 4; return true; }
+   if (la == 8 && lv == 2) { *addr_len = 8; *val_len = 2; return true; }
+   if (la == 6 && lv == 8) { *addr_len = 6; *val_len = 8; return true; }
+   if (la == 8 && lv == 8) { *addr_len = 8; *val_len = 8; return true; }
+   return false;
+}
+
+static bool parse_digits_pair(const char *addr_digits, size_t addr_len,
+                              const char *val_digits, size_t val_len,
+                              uint32_t *addr_out,
+                              uint32_t *val_out,
+                              uint8_t *size_out)
+{
+   size_t i;
+   uint32_t addr = 0, val = 0;
+
+   for (i = 0; i < addr_len; i++)
+      addr = (addr << 4) | (uint32_t)hex_digit(addr_digits[i]);
+   for (i = 0; i < val_len; i++)
+      val = (val << 4) | (uint32_t)hex_digit(val_digits[i]);
+
+   *addr_out = addr & 0x00FFFFFFu;
+   *val_out  = val;
+   *size_out = (uint8_t)(val_len / 2);
+   return true;
+}
+
+bool cheat_parse_one(const char *code,
+                     uint32_t *addr_out,
+                     uint32_t *val_out,
+                     uint8_t *size_out)
+{
+   char buf[CHEAT_PARSE_MAX_HEX + 1];
+   size_t n = 0;
+   size_t addr_len, val_len;
+   uint32_t addr = 0, val = 0;
+   size_t i;
+
+   if (!code || !addr_out || !val_out || !size_out)
+      return false;
+
+   while (*code == ' ' || *code == '\t')
+      code++;
+
+   if (!hex_only_strip(code, buf, sizeof(buf), &n))
+      return false;
+
+   /* Two-field form (10 hex digits total): disambiguate 6+4 vs 8+2.
+    * Use first whitespace run, else last ':', '-', or '.' between fields
+    * ("00003D00 FF", "00003D00:FF", "0000:3D00:FF") so 8+2 is not read as 6+4. */
+   if (n == 10 && (has_ascii_ws(code) || strpbrk(code, ":-.") != NULL))
+   {
+      char left[96];
+      char right[96];
+      char addr_digits[CHEAT_PARSE_MAX_HEX + 1];
+      char val_digits[CHEAT_PARSE_MAX_HEX + 1];
+      size_t la;
+      size_t lv;
+      bool split_ok;
+
+      if (has_ascii_ws(code))
+         split_ok = split_first_ws(code, left, sizeof(left), right, sizeof(right));
+      else
+         split_ok = split_last_cd_sep(code, left, sizeof(left), right, sizeof(right));
+
+      if (!split_ok)
+         return false;
+      if (!hex_only_strip(left, addr_digits, sizeof(addr_digits), &la))
+         return false;
+      if (!hex_only_strip(right, val_digits, sizeof(val_digits), &lv))
+         return false;
+      if (!pair_from_segment_lengths(la, lv, &addr_len, &val_len))
+         return false;
+      return parse_digits_pair(addr_digits, addr_len,
+                               val_digits, val_len,
+                               addr_out, val_out, size_out);
+   }
+
+   /* Layout:  address_hex + value_hex (concatenated after separator strip).
+    * For 10 digits with no field boundary, use 6+4 (PAR short-address + word). */
+   switch (n)
+   {
+      case  8: addr_len = 6; val_len = 2; break;  /* 6 + byte  */
+      case 10: addr_len = 6; val_len = 4; break;  /* 6 + word (contiguous) */
+      case 12: addr_len = 8; val_len = 4; break;  /* 8 + word (PAR) */
+      case 14: addr_len = 6; val_len = 8; break;  /* 6 + long  */
+      case 16: addr_len = 8; val_len = 8; break;  /* 8 + long  */
+      default: return false;
+   }
+
+   for (i = 0; i < addr_len; i++)
+      addr = (addr << 4) | (uint32_t)hex_digit(buf[i]);
+   for (i = 0; i < val_len; i++)
+      val  = (val  << 4) | (uint32_t)hex_digit(buf[addr_len + i]);
+
+   *addr_out = addr & 0x00FFFFFFu;
+   *val_out  = val;
+   *size_out = (uint8_t)(val_len / 2);
+   return true;
+}
+
+void cheat_list_remove_index(cheat_list_t *list, unsigned index)
+{
+   unsigned i, j = 0;
+   if (!list)
+      return;
+   for (i = 0; i < list->count; i++)
+   {
+      if (list->entries[i].tag == index)
+         continue;
+      if (j != i)
+         list->entries[j] = list->entries[i];
+      j++;
+   }
+   list->count = j;
+}
+
+void cheat_list_reset(cheat_list_t *list)
+{
+   if (!list)
+      return;
+   memset(list, 0, sizeof(*list));
+}
+
+void cheat_list_set(cheat_list_t *list,
+                    unsigned index,
+                    bool enabled,
+                    const char *code)
+{
+   const char *p;
+   const char *start;
+
+   if (!list)
+      return;
+
+   cheat_list_remove_index(list, index);
+   if (!enabled)
+      return;
+
+   if (!code)
+      return;
+
+   p = code;
+   start = p;
+   for (;;)
+   {
+      if (*p == '+' || *p == '\n' || *p == '\r' || *p == '\0')
+      {
+         size_t len = (size_t)(p - start);
+         /* Reject oversized segments outright (do not truncate and parse). */
+         if (len > 0 && len <= CHEAT_SEGMENT_INPUT_MAX &&
+             list->count < CHEAT_MAX_ENTRIES)
+         {
+            char tmp[CHEAT_SEGMENT_TMP_SIZE];
+            cheat_entry_t c;
+
+            memcpy(tmp, start, len);
+            tmp[len] = '\0';
+            if (cheat_parse_one(tmp, &c.address, &c.value, &c.size))
+            {
+               c.tag     = index;
+               c.enabled = true;
+               list->entries[list->count++] = c;
+            }
+         }
+         if (*p == '\0')
+            break;
+         start = p + 1;
+      }
+      p++;
+   }
+}
+
+void cheat_list_apply(const cheat_list_t *list,
+                      cheat_write_fn write,
+                      void *user)
+{
+   unsigned i;
+   if (!list || !write)
+      return;
+   for (i = 0; i < list->count; i++)
+   {
+      if (!list->entries[i].enabled)
+         continue;
+      write(list->entries[i].address,
+            list->entries[i].value,
+            list->entries[i].size,
+            user);
+   }
+}

--- a/src/cheat.h
+++ b/src/cheat.h
@@ -1,0 +1,94 @@
+#ifndef VJAG_CHEAT_H
+#define VJAG_CHEAT_H
+
+/*
+ * Atari Jaguar cheat-code engine.
+ *
+ * Supports the Pro Action Replay / GameShark-style hex format commonly
+ * distributed for Jaguar games. Separators (space, colon, hyphen, dot)
+ * between the address and the value are optional and ignored, so the
+ * following all parse to the same thing:
+ *
+ *    "00003D00 FFFF"       (PAR)
+ *    "00003D00:FFFF"
+ *    "0000:3D00-FFFF"
+ *    "00003D00FFFF"
+ *
+ * Contiguous 10 hex digits use 6+4 (short address + word). For an 8-digit
+ * address plus a byte (8+2), separate fields with ASCII whitespace and/or a
+ * single boundary using ':', '-', or '.' before the value (e.g.
+ * "00003D00 FF", "00003D00:FF", "0000:3D00:FF"). You can also write
+ * "ABCDEF 1234" to force 6+4 with a visible boundary.
+ *
+ * A single `retro_cheat_set` string may contain multiple codes separated
+ * by '+' or newlines; each is parsed and stored independently under the
+ * same index so the frontend can toggle them as a group.
+ *
+ * Application is modelled as a callback: the engine is independent of
+ * any specific memory implementation, which keeps the parser and list
+ * management unit-testable in isolation from the emulator.
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+#include <boolean.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define CHEAT_MAX_ENTRIES 256
+
+/* Max chars in one '+' or newline-separated segment (matches scratch buffer below). */
+#define CHEAT_SEGMENT_INPUT_MAX 63
+#define CHEAT_SEGMENT_TMP_SIZE  (CHEAT_SEGMENT_INPUT_MAX + 1)
+
+typedef struct {
+   uint32_t address;   /* 24-bit Jaguar bus address */
+   uint32_t value;
+   uint8_t  size;      /* 1=byte, 2=word, 4=long */
+   unsigned tag;       /* retro_cheat_set index (for removal on toggle) */
+   bool     enabled;
+} cheat_entry_t;
+
+typedef struct {
+   cheat_entry_t entries[CHEAT_MAX_ENTRIES];
+   unsigned      count;
+} cheat_list_t;
+
+/* Parse a single code string into its components. Returns true iff the
+ * string contains a well-formed hex address/value pair (after stripping
+ * the ignored separators). On success, *addr is masked to 24 bits. */
+bool cheat_parse_one(const char *code,
+                     uint32_t *addr,
+                     uint32_t *value,
+                     uint8_t *size);
+
+/* Remove every cheat tagged with `index`. Safe to call with no matches. */
+void cheat_list_remove_index(cheat_list_t *list, unsigned index);
+
+/* Parse `code` (which may contain multiple '+' or newline-separated
+ * entries) and install each successfully-parsed entry under `index`.
+ * When enabled=false, simply removes any existing entries for `index`. */
+void cheat_list_set(cheat_list_t *list,
+                    unsigned index,
+                    bool enabled,
+                    const char *code);
+
+/* Clear every entry. */
+void cheat_list_reset(cheat_list_t *list);
+
+/* Callback used by cheat_list_apply to perform the memory write.
+ * `size` is 1, 2, or 4 bytes. */
+typedef void (*cheat_write_fn)(uint32_t addr, uint32_t value,
+                               uint8_t size, void *user);
+
+void cheat_list_apply(const cheat_list_t *list,
+                      cheat_write_fn write,
+                      void *user);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* VJAG_CHEAT_H */

--- a/src/dac.c
+++ b/src/dac.c
@@ -194,7 +194,9 @@ void DACWriteWord(uint32_t offset, uint16_t data, uint32_t who)
       JERRYI2SCallback();
    }
    else if (offset == SMODE + 2)
+   {
       *smode = data;
+   }
 }
 
 uint8_t DACReadByte(uint32_t offset, uint32_t who)

--- a/src/dsp.c
+++ b/src/dsp.c
@@ -2518,6 +2518,7 @@ INLINE static void DSP_xor(void)
 size_t DSPStateSave(uint8_t *buf)
 {
    uint8_t *start = buf;
+   uint8_t active_bank;
 
    STATE_SAVE_BUF(buf, dsp_ram_8, sizeof(dsp_ram_8));
    STATE_SAVE_VAR(buf, dsp_pc);
@@ -2536,7 +2537,7 @@ size_t DSPStateSave(uint8_t *buf)
    STATE_SAVE_BUF(buf, dsp_reg_bank_0, sizeof(dsp_reg_bank_0));
    STATE_SAVE_BUF(buf, dsp_reg_bank_1, sizeof(dsp_reg_bank_1));
 
-   uint8_t active_bank = (dsp_reg == dsp_reg_bank_0) ? 0 : 1;
+   active_bank = (dsp_reg == dsp_reg_bank_0) ? 0 : 1;
    STATE_SAVE_VAR(buf, active_bank);
 
    STATE_SAVE_VAR(buf, dsp_opcode_first_parameter);
@@ -2562,6 +2563,7 @@ size_t DSPStateSave(uint8_t *buf)
 size_t DSPStateLoad(const uint8_t *buf)
 {
    const uint8_t *start = buf;
+   uint8_t active_bank;
 
    STATE_LOAD_BUF(buf, dsp_ram_8, sizeof(dsp_ram_8));
    STATE_LOAD_VAR(buf, dsp_pc);
@@ -2580,7 +2582,6 @@ size_t DSPStateLoad(const uint8_t *buf)
    STATE_LOAD_BUF(buf, dsp_reg_bank_0, sizeof(dsp_reg_bank_0));
    STATE_LOAD_BUF(buf, dsp_reg_bank_1, sizeof(dsp_reg_bank_1));
 
-   uint8_t active_bank;
    STATE_LOAD_VAR(buf, active_bank);
    if (active_bank == 0)
    {

--- a/src/dsp.c
+++ b/src/dsp.c
@@ -15,6 +15,7 @@
 //
 
 #include "dsp.h"
+#include "dsp_acc40.h"
 
 #include <stdlib.h>
 #include "dac.h"
@@ -1250,8 +1251,8 @@ INLINE static void dsp_opcode_addqt(void)
 INLINE static void dsp_opcode_imacn(void)
 {
 	int32_t res = (int16_t)RM * (int16_t)RN;
-	dsp_acc += (int64_t)res;
-//Should we AND the result to fit into 40 bits here???
+
+	dsp_acc_mac_apply(&dsp_acc, res);
 }
 
 
@@ -1379,7 +1380,8 @@ INLINE static void dsp_opcode_imultn(void)
 {
 	// This is OK, since this multiply won't overflow 32 bits...
 	int32_t res = (int32_t)((int16_t)RN * (int16_t)RM);
-	dsp_acc = (int64_t)res;
+
+	dsp_acc_set_from_i32(&dsp_acc, res);
 	SET_ZN(res);
 }
 
@@ -1828,8 +1830,8 @@ INLINE static void DSP_div(void)
 INLINE static void DSP_imacn(void)
 {
 	int32_t res = (int16_t)PRM * (int16_t)PRN;
-	dsp_acc += (int64_t)res;
-//Should we AND the result to fit into 40 bits here???
+
+	dsp_acc_mac_apply(&dsp_acc, res);
 	NO_WRITEBACK;
 }
 
@@ -1843,7 +1845,8 @@ INLINE static void DSP_imultn(void)
 {
 	// This is OK, since this multiply won't overflow 32 bits...
 	int32_t res = (int32_t)((int16_t)PRN * (int16_t)PRM);
-	dsp_acc = (int64_t)res;
+
+	dsp_acc_set_from_i32(&dsp_acc, res);
 	SET_ZN(res);
 	NO_WRITEBACK;
 }

--- a/src/dsp_acc40.h
+++ b/src/dsp_acc40.h
@@ -1,0 +1,53 @@
+/*
+ * Jaguar DSP MAC accumulator is 40-bit signed two's complement.
+ * Store only bits 39..0 in the low bits of uint64_t (bits 63..40 must stay zero)
+ * so RESMAC and control-register reads (dsp_acc >> 32) stay correct.
+ */
+
+#ifndef DSP_ACC40_H
+#define DSP_ACC40_H
+
+#include <stdint.h>
+
+#ifndef DSP_ACC40_INLINE
+#if defined(_MSC_VER)
+#define DSP_ACC40_INLINE static __inline
+#else
+#define DSP_ACC40_INLINE static inline
+#endif
+#endif
+
+#define DSP_ACC_U40_MASK UINT64_C(0xFFFFFFFFFF)
+
+DSP_ACC40_INLINE int64_t dsp_acc_i40_signed(uint64_t raw)
+{
+	uint64_t u = raw & DSP_ACC_U40_MASK;
+	if (u & (UINT64_C(1) << 39))
+		return (int64_t)(u | UINT64_C(0xFFFFFF0000000000));
+	return (int64_t)u;
+}
+
+DSP_ACC40_INLINE uint64_t dsp_acc_wrap_store_i40(int64_t v)
+{
+	int64_t t;
+
+	t = v & (((int64_t)1 << 40) - 1);
+	if (t & ((int64_t)1 << 39))
+		t |= ~(((int64_t)1 << 40) - 1);
+	return (uint64_t)t & DSP_ACC_U40_MASK;
+}
+
+DSP_ACC40_INLINE void dsp_acc_mac_apply(uint64_t *acc, int32_t prod)
+{
+	int64_t a;
+
+	a = dsp_acc_i40_signed(*acc);
+	*acc = dsp_acc_wrap_store_i40(a + (int64_t)prod);
+}
+
+DSP_ACC40_INLINE void dsp_acc_set_from_i32(uint64_t *acc, int32_t res)
+{
+	*acc = dsp_acc_wrap_store_i40((int64_t)res);
+}
+
+#endif

--- a/src/eeprom.c
+++ b/src/eeprom.c
@@ -16,7 +16,7 @@
 #include "eeprom.h"
 
 #include <stdlib.h>
-#include <stdbool.h>
+#include <boolean.h>
 #include <string.h>								// For memset
 
 uint16_t eeprom_ram[64];

--- a/src/event.c
+++ b/src/event.c
@@ -59,7 +59,9 @@ void InitializeEventList(void)
    for(i = 0; i < EVENT_LIST_SIZE; i++)
    {
       eventList[i].valid = false;
+      eventList[i].eventTime = 0.0;
       eventListJERRY[i].valid = false;
+      eventListJERRY[i].eventTime = 0.0;
    }
 
    numberOfEvents = 0;
@@ -156,14 +158,13 @@ void AdjustCallbackTime(void (* callback)(void), double time)
 //
 double GetTimeToNextEvent(int type/*= EVENT_MAIN*/)
 {
-   double time;
+   double time = 1e30;
    unsigned i;
    if (type == EVENT_MAIN)
    {
-      time      = eventList[0].eventTime;
       nextEvent = 0;
 
-      for(i = 1; i < EVENT_LIST_SIZE; i++)
+      for(i = 0; i < EVENT_LIST_SIZE; i++)
       {
          if (eventList[i].valid && (eventList[i].eventTime < time))
          {
@@ -174,10 +175,9 @@ double GetTimeToNextEvent(int type/*= EVENT_MAIN*/)
    }
    else
    {
-      time           = eventListJERRY[0].eventTime;
       nextEventJERRY = 0;
 
-      for(i = 1; i < EVENT_LIST_SIZE; i++)
+      for(i = 0; i < EVENT_LIST_SIZE; i++)
       {
          if (eventListJERRY[i].valid && (eventListJERRY[i].eventTime < time))
          {

--- a/src/file.c
+++ b/src/file.c
@@ -66,6 +66,8 @@ bool JaguarLoadFile(uint8_t *buffer, size_t bufsize)
 {
    int fileType;
    jaguarROMSize = bufsize;
+   jaguarLoadedRAMStart = 0;
+   jaguarLoadedRAMEnd = 0;
 
    if (jaguarROMSize == 0)
       return false;
@@ -104,6 +106,8 @@ bool JaguarLoadFile(uint8_t *buffer, size_t bufsize)
                codeSize = GET32(buffer, 0x02) + GET32(buffer, 0x06);
       memcpy(jagMemSpace + loadAddress, buffer + 0x24, codeSize);
       jaguarRunAddress = loadAddress;
+      jaguarLoadedRAMStart = loadAddress;
+      jaguarLoadedRAMEnd = loadAddress + codeSize;
       return true;
    }
    else if (fileType == JST_ABS_TYPE2)
@@ -112,6 +116,8 @@ bool JaguarLoadFile(uint8_t *buffer, size_t bufsize)
                codeSize = GET32(buffer, 0x18) + GET32(buffer, 0x1C);
       memcpy(jagMemSpace + loadAddress, buffer + 0xA8, codeSize);
       jaguarRunAddress = runAddress;
+      jaguarLoadedRAMStart = loadAddress;
+      jaguarLoadedRAMEnd = loadAddress + codeSize;
       return true;
    }
    // NB: This is *wrong*
@@ -124,8 +130,11 @@ bool JaguarLoadFile(uint8_t *buffer, size_t bufsize)
       // Still need to do some checking here for type 2 vs. type 3. This assumes 3
       // Also, JAGR vs. JAGL (word command size vs. long command size)
       uint32_t loadAddress = GET32(buffer, 0x22), runAddress = GET32(buffer, 0x2A);
-      memcpy(jagMemSpace + loadAddress, buffer + 0x2E, jaguarROMSize - 0x2E);
+      uint32_t codeSize = jaguarROMSize - 0x2E;
+      memcpy(jagMemSpace + loadAddress, buffer + 0x2E, codeSize);
       jaguarRunAddress = runAddress;
+      jaguarLoadedRAMStart = loadAddress;
+      jaguarLoadedRAMEnd = loadAddress + codeSize;
 
       // Hmm. Is this kludge necessary?
       SET32(jaguarMainRAM, 0x10, 0x00001000);		// Set Exception #4 (Illegal Instruction)
@@ -136,8 +145,11 @@ bool JaguarLoadFile(uint8_t *buffer, size_t bufsize)
    else if (fileType == JST_WTFOMGBBQ)
    {
       uint32_t loadAddress = (buffer[0x1F] << 24) | (buffer[0x1E] << 16) | (buffer[0x1D] << 8) | buffer[0x1C];
-      memcpy(jagMemSpace + loadAddress, buffer + 0x20, jaguarROMSize - 0x20);
+      uint32_t codeSize = jaguarROMSize - 0x20;
+      memcpy(jagMemSpace + loadAddress, buffer + 0x20, codeSize);
       jaguarRunAddress = loadAddress;
+      jaguarLoadedRAMStart = loadAddress;
+      jaguarLoadedRAMEnd = loadAddress + codeSize;
       return true;
    }
 

--- a/src/gpu.c
+++ b/src/gpu.c
@@ -1700,6 +1700,7 @@ INLINE static void gpu_opcode_sh(void)
 size_t GPUStateSave(uint8_t *buf)
 {
    uint8_t *start = buf;
+   uint8_t active_bank;
 
    STATE_SAVE_BUF(buf, gpu_ram_8, sizeof(gpu_ram_8));
    STATE_SAVE_VAR(buf, gpu_pc);
@@ -1719,7 +1720,7 @@ size_t GPUStateSave(uint8_t *buf)
    STATE_SAVE_BUF(buf, gpu_reg_bank_1, sizeof(gpu_reg_bank_1));
 
    /* Save which register bank is active (0 or 1) */
-   uint8_t active_bank = (gpu_reg == gpu_reg_bank_0) ? 0 : 1;
+   active_bank = (gpu_reg == gpu_reg_bank_0) ? 0 : 1;
    STATE_SAVE_VAR(buf, active_bank);
 
    STATE_SAVE_VAR(buf, gpu_instruction);
@@ -1735,6 +1736,7 @@ size_t GPUStateSave(uint8_t *buf)
 size_t GPUStateLoad(const uint8_t *buf)
 {
    const uint8_t *start = buf;
+   uint8_t active_bank;
 
    STATE_LOAD_BUF(buf, gpu_ram_8, sizeof(gpu_ram_8));
    STATE_LOAD_VAR(buf, gpu_pc);
@@ -1754,7 +1756,6 @@ size_t GPUStateLoad(const uint8_t *buf)
    STATE_LOAD_BUF(buf, gpu_reg_bank_1, sizeof(gpu_reg_bank_1));
 
    /* Restore register bank pointers */
-   uint8_t active_bank;
    STATE_LOAD_VAR(buf, active_bank);
    if (active_bank == 0)
    {

--- a/src/gpu.c
+++ b/src/gpu.c
@@ -24,8 +24,10 @@
 
 #include "gpu.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>								// For memset
+#include "log.h"
 #include "dsp.h"
 #include "jaguar.h"
 #include "m68000/m68kinterface.h"
@@ -34,6 +36,13 @@
 
 // Seems alignment in loads & stores was off...
 #define GPU_CORRECT_ALIGNMENT
+
+#define GPU_TRACE_DEBUG 0
+#if GPU_TRACE_DEBUG
+#define GPU_TRACE(...) LOG_DBG("[GPU-TRACE] " __VA_ARGS__)
+#else
+#define GPU_TRACE(...) do {} while(0)
+#endif
 
 // For GPU dissasembly...
 

--- a/src/gpu.h
+++ b/src/gpu.h
@@ -32,6 +32,8 @@ uint32_t GPUGetPC(void);
 void GPUReleaseTimeslice(void);
 void GPUResetStats(void);
 uint32_t GPUReadPC(void);
+int GPUIsRunning(void);
+void GPUDumpState(const char *tag);
 
 // GPU interrupt numbers (from $F00100, bits 4-8)
 

--- a/src/jaguar.c
+++ b/src/jaguar.c
@@ -111,6 +111,7 @@ extern uint8_t jagMemSpace[];
 // Internal variables
 
 uint32_t jaguarMainROMCRC32, jaguarROMSize, jaguarRunAddress;
+uint32_t jaguarLoadedRAMStart, jaguarLoadedRAMEnd;
 
 bool jaguarCartInserted = false;
 bool lowerField = false;
@@ -645,11 +646,17 @@ void JaguarReset(void)
 {
    unsigned i;
 
-   // Only problem with this approach: It wipes out RAM loaded files...!
-   // Contents of local RAM are quasi-stable; we simulate this by randomizing RAM contents
+   // Contents of local RAM are quasi-stable; we simulate this by randomizing RAM contents.
+   // Skip over any region where a RAM-loaded executable resides so we don't wipe it out.
    JaguarSeedPRNG(12345);
    for(i=8; i<0x200000; i+=4)
-      *((uint32_t *)(&jaguarMainRAM[i])) = JaguarRand();
+   {
+      uint32_t r = JaguarRand();
+      if (jaguarLoadedRAMEnd > jaguarLoadedRAMStart
+          && i >= jaguarLoadedRAMStart && i < jaguarLoadedRAMEnd)
+         continue;
+      *((uint32_t *)(&jaguarMainRAM[i])) = r;
+   }
 
    // New timer base code stuffola...
    InitializeEventList();

--- a/src/jaguar.h
+++ b/src/jaguar.h
@@ -42,6 +42,7 @@ extern uint32_t bpmAddress1;
 extern "C" {
 #endif
 extern uint32_t jaguarMainROMCRC32, jaguarROMSize, jaguarRunAddress;
+extern uint32_t jaguarLoadedRAMStart, jaguarLoadedRAMEnd;
 #ifdef __cplusplus
 }
 #endif

--- a/src/jerry.c
+++ b/src/jerry.c
@@ -153,8 +153,10 @@
 
 #include "jerry.h"
 
+#include <stdio.h>
 #include <string.h>								// For memcpy
 #include "cdrom.h"
+#include "log.h"
 #include "dac.h"
 #include "dsp.h"
 #include "eeprom.h"
@@ -168,6 +170,13 @@
 #include "wavetable.h"
 
 //Note that 44100 Hz requires samples every 22.675737 usec.
+
+#define JERRY_TRACE_DEBUG 0
+#if JERRY_TRACE_DEBUG
+#define JERRY_TRACE(...) LOG_DBG("[JERRY-TRACE] " __VA_ARGS__)
+#else
+#define JERRY_TRACE(...) ((void)0)
+#endif
 
 uint8_t jerry_ram_8[0x10000];
 
@@ -221,7 +230,7 @@ void JERRYResetPIT2(void)
 {
    RemoveCallback(JERRYPIT2Callback);
 
-   if (JERRYPIT1Prescaler | JERRYPIT1Divider)
+   if (JERRYPIT2Prescaler | JERRYPIT2Divider)
    {
       double usecs = (float)(JERRYPIT2Prescaler + 1) * (float)(JERRYPIT2Divider + 1) * RISC_CYCLE_IN_USEC;
       SetCallbackTime(JERRYPIT2Callback, usecs, EVENT_JERRY);
@@ -231,6 +240,7 @@ void JERRYResetPIT2(void)
 
 // This is the cause of the regressions in Cybermorph and Missile Command 3D...
 // Solution: Probably have to check the DSP enable bit before sending these thru.
+
 void JERRYPIT1Callback(void)
 {
    if (TOMIRQEnabled(IRQ_DSP))
@@ -364,7 +374,11 @@ bool JERRYIRQEnabled(int irq)
 void JERRYSetPendingIRQ(int irq)
 {
    // This is the shadow of INT (it's a split RO/WO register)
+   uint16_t oldPending = jerryPendingInterrupt;
    jerryPendingInterrupt |= irq;
+   if (irq == IRQ2_EXTERNAL && !(oldPending & IRQ2_EXTERNAL))
+      JERRY_TRACE("External IRQ pending set (mask=$%02X pending=$%02X)\n",
+                  jerryInterruptMask & 0xFF, jerryPendingInterrupt & 0xFF);
 }
 
 
@@ -447,7 +461,18 @@ uint16_t JERRYReadWord(uint32_t offset, uint32_t who/*=UNKNOWN*/)
       }
    }
    else if (offset == 0xF10020)
+   {
+      if (jerryPendingInterrupt & IRQ2_EXTERNAL)
+      {
+         static uint32_t extReadCount = 0;
+         extReadCount++;
+         if (extReadCount <= 10 || (extReadCount % 10000) == 0)
+            JERRY_TRACE("J_INT read=$%04X (ext pending) mask=$%04X [68K_PC=$%06X] #%u\n",
+                        jerryPendingInterrupt, jerryInterruptMask,
+                        m68k_get_reg(NULL, M68K_REG_PC), extReadCount);
+      }
       return jerryPendingInterrupt;
+   }
    else if (offset == 0xF14000)
       return (JoystickReadWord(offset) & 0xFFFE) | EepromReadWord(offset);
    else if ((offset >= 0xF14002) && (offset < 0xF14003))
@@ -568,8 +593,18 @@ void JERRYWriteWord(uint32_t offset, uint16_t data, uint32_t who/*=UNKNOWN*/)
    // JERRY -> 68K interrupt enables/latches (need to be handled!)
    else if (offset >= 0xF10020 && offset <= 0xF10022)
    {
+      uint16_t oldMask = jerryInterruptMask;
+      uint16_t oldPending = jerryPendingInterrupt;
       jerryInterruptMask = data & 0xFF;
       jerryPendingInterrupt &= ~(data >> 8);
+      if (oldMask != jerryInterruptMask || oldPending != jerryPendingInterrupt)
+      {
+         JERRY_TRACE("J_INT write word data=$%04X who=%u mask $%02X->$%02X pending $%02X->$%02X%s%s\n",
+                     data, who, oldMask & 0xFF, jerryInterruptMask & 0xFF,
+                     oldPending & 0xFF, jerryPendingInterrupt & 0xFF,
+                     (!(oldMask & IRQ2_EXTERNAL) && (jerryInterruptMask & IRQ2_EXTERNAL)) ? " extena-on" : "",
+                     ((oldPending & IRQ2_EXTERNAL) && !(jerryPendingInterrupt & IRQ2_EXTERNAL)) ? " extclr" : "");
+      }
       return;
    }
    else if (offset >= 0xF14000 && offset < 0xF14003)

--- a/src/log.h
+++ b/src/log.h
@@ -1,0 +1,36 @@
+#ifndef VJ_LOG_H
+#define VJ_LOG_H
+
+#include <stdio.h>
+#include <stdarg.h>
+#include "libretro.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern retro_log_printf_t vj_log_cb;
+
+static inline void vj_log_stderr(const char *fmt, ...)
+{
+   va_list ap;
+   va_start(ap, fmt);
+   vfprintf(stderr, fmt, ap);
+   va_end(ap);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#define VJ_LOG(level, ...) do { \
+   if (vj_log_cb) vj_log_cb(level, __VA_ARGS__); \
+   else vj_log_stderr(__VA_ARGS__); \
+} while (0)
+
+#define LOG_DBG(...) VJ_LOG(RETRO_LOG_DEBUG, __VA_ARGS__)
+#define LOG_INF(...) VJ_LOG(RETRO_LOG_INFO,  __VA_ARGS__)
+#define LOG_WRN(...) VJ_LOG(RETRO_LOG_WARN,  __VA_ARGS__)
+#define LOG_ERR(...) VJ_LOG(RETRO_LOG_ERROR, __VA_ARGS__)
+
+#endif

--- a/src/m68000/cpuemu.c
+++ b/src/m68000/cpuemu.c
@@ -14962,9 +14962,14 @@ unsigned long CPUFUNC(op_6101_4)(uint32_t opcode) /* BSR */
 unsigned long CPUFUNC(op_61ff_4)(uint32_t opcode) /* BSR */
 {
 	OpcodeFamily = 54; CurrentInstrCycles = 18; 
-{{	int32_t src = get_ilong(2);
-	int32_t s = (int32_t)src + 2;
-	m68k_do_bsr(m68k_getpc() + 6, s);
+{{	/* Atari Jaguar quirk: the 'aln' linker emits BSR with an 8-bit
+	 * displacement of $FF (the 68020+ "long-form" escape) but writes the
+	 * ABSOLUTE TARGET ADDRESS into the 32-bit displacement slot instead
+	 * of a PC-relative displacement. Real 68000 hardware doesn't have
+	 * BSR.L at all, so any $61FF we see in a Jaguar binary uses this
+	 * convention. Treat the operand as an absolute jump target. */
+	uint32_t target = (uint32_t)get_ilong(2);
+	m68k_do_jsr(m68k_getpc() + 6, target);
 }}return 18;
 }
 unsigned long CPUFUNC(op_6200_4)(uint32_t opcode) /* Bcc */
@@ -46548,14 +46553,15 @@ return 18;
 unsigned long CPUFUNC(op_61ff_5)(uint32_t opcode) /* BSR */
 {
 	OpcodeFamily = 54; CurrentInstrCycles = 18; 
-{{	int32_t src = get_ilong_prefetch(2);
-	int32_t s = (int32_t)src + 2;
-	if (src & 1) {
+{{	/* See op_61ff_4: aln writes the absolute target address into the
+	 * 32-bit displacement slot of BSR.L. Treat operand as absolute. */
+	uint32_t target = (uint32_t)get_ilong_prefetch(2);
+	if (target & 1) {
 		last_addr_for_exception_3 = m68k_getpc() + 2;
-		last_fault_for_exception_3 = m68k_getpc() + s;
+		last_fault_for_exception_3 = target;
 		last_op_for_exception_3 = opcode; Exception(3,0,M68000_EXC_SRC_CPU); goto endlabel2596;
 	}
-	m68k_do_bsr(m68k_getpc() + 6, s);
+	m68k_do_jsr(m68k_getpc() + 6, target);
 fill_prefetch_0 ();
 }}endlabel2596: ;
 return 18;

--- a/src/m68000/m68kinterface.c
+++ b/src/m68000/m68kinterface.c
@@ -411,6 +411,7 @@ void BuildCPUFunctionTable(void)
 size_t M68KStateSave(uint8_t *buf)
 {
 	uint8_t *start = buf;
+	uint32_t pc_p_offset, pc_oldp_offset;
 
 	/* Save register struct fields individually (not the raw struct,
 	 * because pc_p/pc_oldp are pointers that differ per session). */
@@ -435,8 +436,8 @@ size_t M68KStateSave(uint8_t *buf)
 	STATE_SAVE_VAR(buf, regs.interruptCycles);
 
 	/* Save pc_p and pc_oldp as offsets from jagMemSpace */
-	uint32_t pc_p_offset = (uint32_t)(regs.pc_p ? (regs.pc_p - jagMemSpace) : 0xFFFFFFFF);
-	uint32_t pc_oldp_offset = (uint32_t)(regs.pc_oldp ? (regs.pc_oldp - jagMemSpace) : 0xFFFFFFFF);
+	pc_p_offset = (uint32_t)(regs.pc_p ? (regs.pc_p - jagMemSpace) : 0xFFFFFFFF);
+	pc_oldp_offset = (uint32_t)(regs.pc_oldp ? (regs.pc_oldp - jagMemSpace) : 0xFFFFFFFF);
 	STATE_SAVE_VAR(buf, pc_p_offset);
 	STATE_SAVE_VAR(buf, pc_oldp_offset);
 
@@ -452,6 +453,7 @@ size_t M68KStateSave(uint8_t *buf)
 size_t M68KStateLoad(const uint8_t *buf)
 {
 	const uint8_t *start = buf;
+	uint32_t pc_p_offset, pc_oldp_offset;
 
 	STATE_LOAD_BUF(buf, regs.regs, sizeof(regs.regs));
 	STATE_LOAD_VAR(buf, regs.usp);
@@ -474,7 +476,6 @@ size_t M68KStateLoad(const uint8_t *buf)
 	STATE_LOAD_VAR(buf, regs.interruptCycles);
 
 	/* Reconstruct pc_p and pc_oldp from offsets */
-	uint32_t pc_p_offset, pc_oldp_offset;
 	STATE_LOAD_VAR(buf, pc_p_offset);
 	STATE_LOAD_VAR(buf, pc_oldp_offset);
 	regs.pc_p = (pc_p_offset != 0xFFFFFFFF) ? (jagMemSpace + pc_p_offset) : NULL;

--- a/src/m68000/m68kinterface.c
+++ b/src/m68000/m68kinterface.c
@@ -349,8 +349,174 @@ void m68k_end_timeslice(void)
 }
 
 
+/* Read a 32-bit operand from any addressable EA the wrapper code uses.
+ * The Removers/aln-built Jaguar binaries we care about always reach MULL/DIVL
+ * with the EA = data-register-direct (mode 0). Other modes (immediate,
+ * abs.W/L, (An), etc.) are emulated for completeness. */
+static int read_long_ea(uint32_t opcode, uint32_t *out)
+{
+	uint32_t mode = (opcode >> 3) & 0x7;
+	uint32_t reg  = opcode & 0x7;
+	uint32_t ea;
+
+	switch (mode)
+	{
+	case 0: /* Dn */
+		*out = m68k_dreg(regs, reg);
+		return 0;
+	case 1: /* An */
+		*out = m68k_areg(regs, reg);
+		return 0;
+	case 2: /* (An) */
+		*out = m68k_read_memory_32(m68k_areg(regs, reg));
+		return 0;
+	case 5: /* (d16,An) */
+	{
+		int16_t d = (int16_t)get_iword(4);
+		*out = m68k_read_memory_32(m68k_areg(regs, reg) + d);
+		return 2;
+	}
+	case 7:
+		switch (reg)
+		{
+		case 0: /* (xxx).W */
+			ea = (int32_t)(int16_t)get_iword(4);
+			*out = m68k_read_memory_32(ea);
+			return 2;
+		case 1: /* (xxx).L */
+			ea = (uint32_t)get_ilong(4);
+			*out = m68k_read_memory_32(ea);
+			return 4;
+		case 4: /* #imm */
+			*out = (uint32_t)get_ilong(4);
+			return 4;
+		}
+		break;
+	}
+	return -1;
+}
+
+/* Emulate the 68020+ MULL / DIVL instructions on a 68000-only core.
+ * The Removers Library + m68k-atari-mint-gcc toolchain emits these for
+ * 32x32 multiply and divide; without them, our binaries hard-hang inside
+ * libgcc helpers. Returns 1 if handled, 0 to fall through to a true illegal
+ * exception. */
+static int handle_68020_mull_divl(uint32_t opcode)
+{
+	uint32_t base = opcode & 0xFFC0;
+	uint16_t ext;
+	uint32_t src;
+	int extra;
+
+	if (base != 0x4C00 && base != 0x4C40)
+		return 0;
+
+	ext = (uint16_t)get_iword(2);
+	if (ext & 0x83F8)
+		return 0;	/* reserved bits set — not a clean MULL/DIVL */
+
+	extra = read_long_ea(opcode, &src);
+	if (extra < 0)
+		return 0;
+
+	{
+		uint32_t Dl = (ext >> 12) & 0x7;
+		uint32_t Dh = ext & 0x7;
+		int      sz = (ext >> 10) & 0x1;	/* 0=32-bit, 1=64-bit */
+		int      sg = (ext >> 11) & 0x1;	/* 0=unsigned, 1=signed */
+
+		if (base == 0x4C00)	/* MULL */
+		{
+			uint32_t a = m68k_dreg(regs, Dl);
+			uint32_t b = src;
+			if (sz == 0)
+			{
+				uint32_t r = a * b;
+				m68k_dreg(regs, Dl) = r;
+				SET_NFLG(r >> 31);
+				SET_ZFLG(r == 0);
+				SET_VFLG(0); SET_CFLG(0);
+			}
+			else
+			{
+				uint64_t prod;
+				if (sg)
+					prod = (uint64_t)((int64_t)(int32_t)a * (int64_t)(int32_t)b);
+				else
+					prod = (uint64_t)a * (uint64_t)b;
+				m68k_dreg(regs, Dl) = (uint32_t)prod;
+				m68k_dreg(regs, Dh) = (uint32_t)(prod >> 32);
+				SET_NFLG((prod >> 63) & 1);
+				SET_ZFLG(prod == 0);
+				SET_VFLG(0); SET_CFLG(0);
+			}
+		}
+		else			/* DIVL */
+		{
+			uint32_t divisor = src;
+			if (divisor == 0)
+			{
+				m68k_incpc(2 + extra);
+				Exception(0x05, 0, M68000_EXC_SRC_CPU);
+				return 1;
+			}
+			if (sz == 0)
+			{
+				uint32_t a = m68k_dreg(regs, Dl);
+				if (sg)
+				{
+					int32_t  q = (int32_t)a / (int32_t)divisor;
+					int32_t  r = (int32_t)a % (int32_t)divisor;
+					m68k_dreg(regs, Dl) = (uint32_t)q;
+					if (Dh != Dl) m68k_dreg(regs, Dh) = (uint32_t)r;
+					SET_NFLG(q < 0); SET_ZFLG(q == 0);
+				}
+				else
+				{
+					uint32_t q = a / divisor;
+					uint32_t r = a % divisor;
+					m68k_dreg(regs, Dl) = q;
+					if (Dh != Dl) m68k_dreg(regs, Dh) = r;
+					SET_NFLG(q >> 31); SET_ZFLG(q == 0);
+				}
+			}
+			else	/* 64-bit dividend in Dh:Dl */
+			{
+				uint64_t dividend = ((uint64_t)m68k_dreg(regs, Dh) << 32)
+				                  | (uint64_t)m68k_dreg(regs, Dl);
+				if (sg)
+				{
+					int64_t q = (int64_t)dividend / (int32_t)divisor;
+					int64_t r = (int64_t)dividend % (int32_t)divisor;
+					m68k_dreg(regs, Dl) = (uint32_t)q;
+					m68k_dreg(regs, Dh) = (uint32_t)r;
+					SET_NFLG(q < 0); SET_ZFLG(q == 0);
+				}
+				else
+				{
+					uint64_t q = dividend / divisor;
+					uint64_t r = dividend % divisor;
+					m68k_dreg(regs, Dl) = (uint32_t)q;
+					m68k_dreg(regs, Dh) = (uint32_t)r;
+					SET_NFLG((q >> 63) & 1); SET_ZFLG(q == 0);
+				}
+			}
+			SET_VFLG(0); SET_CFLG(0);
+		}
+	}
+
+	m68k_incpc(4 + extra);
+	return 1;
+}
+
 unsigned long IllegalOpcode(uint32_t opcode)
 {
+	if ((opcode & 0xFF80) == 0x4C00)
+	{
+		if (handle_68020_mull_divl(opcode))
+			return 40;
+	}
+
 	if ((opcode & 0xF000) == 0xF000)
 	{
 		Exception(0x0B, 0, M68000_EXC_SRC_CPU);	// LineF exception...

--- a/src/tom.c
+++ b/src/tom.c
@@ -825,12 +825,38 @@ void TOMDone(void)
 
 uint32_t TOMGetVideoModeWidth(void)
 {
+   uint16_t hdb1 = GET16(tomRam8, HDB1);
+   uint16_t hde = GET16(tomRam8, HDE);
    uint16_t pwidth = ((GET16(tomRam8, VMODE) & PWIDTH) >> 9) + 1;
-   return (vjs.hardwareTypeNTSC ? RIGHT_VISIBLE_HC - LEFT_VISIBLE_HC : RIGHT_VISIBLE_HC_PAL - LEFT_VISIBLE_HC_PAL) / pwidth;
+   uint32_t leftHC = vjs.hardwareTypeNTSC ? LEFT_VISIBLE_HC : LEFT_VISIBLE_HC_PAL;
+   uint32_t rightHC = vjs.hardwareTypeNTSC ? RIGHT_VISIBLE_HC : RIGHT_VISIBLE_HC_PAL;
+
+   // Use the game's actual display window (HDE), clamped to visible area.
+   // The renderer positions content starting at HDB1 via startPos; the total
+   // framebuffer width runs from leftHC to min(HDE, rightHC).
+   uint32_t dispEnd = (hde < rightHC) ? hde : rightHC;
+   if (dispEnd > leftHC && hdb1 > 0)
+   {
+      uint32_t width = (dispEnd - leftHC) / pwidth;
+      if (width > 0 && width <= VIRTUAL_SCREEN_WIDTH)
+         return width;
+   }
+
+   return (rightHC - leftHC) / pwidth;
 }
 
 uint32_t TOMGetVideoModeHeight(void)
 {
+   uint16_t vdb = GET16(tomRam8, VDB);
+   uint16_t vde = GET16(tomRam8, VDE);
+
+   if (vde > vdb)
+   {
+      uint32_t height = (vde - vdb) / 2;
+      if (height > 0 && height <= 256)
+         return height;
+   }
+
    return (vjs.hardwareTypeNTSC ? 240 : 256);
 }
 
@@ -1125,6 +1151,31 @@ int TOMIRQEnabled(int irq)
    // This is the correct byte in big endian... D'oh!
    //	return jaguar_byte_read(0xF000E1) & (1 << irq);
    return tomRam8[INT1 + 1] & (1 << irq);
+}
+
+
+uint16_t TOMIRQControlReg(void)
+{
+   uint16_t val = 0;
+   if (tom_video_int_pending)  val |= 0x0001;
+   if (tom_gpu_int_pending)    val |= 0x0002;
+   if (tom_object_int_pending) val |= 0x0004;
+   if (tom_timer_int_pending)  val |= 0x0008;
+   if (tom_jerry_int_pending)  val |= 0x0010;
+   return val;
+}
+
+
+void TOMSetIRQLatch(int irq, int enabled)
+{
+   switch (irq)
+   {
+      case IRQ_VIDEO:  tom_video_int_pending  = (enabled ? 1 : 0); break;
+      case IRQ_GPU:    tom_gpu_int_pending    = (enabled ? 1 : 0); break;
+      case IRQ_OPFLAG: tom_object_int_pending = (enabled ? 1 : 0); break;
+      case IRQ_TIMER:  tom_timer_int_pending  = (enabled ? 1 : 0); break;
+      case IRQ_DSP:    tom_jerry_int_pending  = (enabled ? 1 : 0); break;
+   }
 }
 
 

--- a/test/test_cheat.c
+++ b/test/test_cheat.c
@@ -1,0 +1,499 @@
+/*
+ * Unit tests for the Jaguar cheat engine (src/cheat.c).
+ *
+ * Self-contained: links only src/cheat.c. `make test` uses `-I src` before
+ * libretro-common, so `<boolean.h>` resolves to src/boolean.h (compatible with
+ * libretro-common) via src/cheat.h.
+ *
+ * Build & run (from repo root): `make test`
+ * or manually:
+ *     cc -O2 -Wall -std=c99 -I src -I libretro-common/include \
+ *        -o test/test_cheat test/test_cheat.c src/cheat.c && ./test/test_cheat
+ *
+ * The tests cover:
+ *   1. cheat_parse_one: all accepted format lengths, every separator style,
+ *      and a broad set of rejection cases (bad chars, wrong length, NULL).
+ *   2. List management: add, toggle off, replacement-on-same-index, and
+ *      capacity clamping when the list is full (additional inserts are
+ *      ignored).
+ *   3. Multi-code strings (the '+' and newline separators used by
+ *      RetroArch's cheat .cht files).
+ *   4. Application against a 16 MB simulated address space, exercising
+ *      byte / word / long writes with big-endian ordering matching the
+ *      Jaguar bus (so the values on the wire match the emulator).
+ *   5. "ROM simulation" end-to-end scenario: a fake CPU main loop writes
+ *      a health value to RAM each frame, the cheat re-applies after the
+ *      frame, and we confirm the patched value survives across frames.
+ *   6. Example codes taken from publicly-documented Jaguar cheat sources
+ *      (Pro Action Replay format) to prove the parser accepts them as-is.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stddef.h>
+
+#include "cheat.h"
+
+static int tests_run = 0;
+static int tests_failed = 0;
+
+#define CHECK(expr) do {                                                  \
+   tests_run++;                                                           \
+   if (!(expr)) {                                                         \
+      tests_failed++;                                                     \
+      fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #expr);     \
+   }                                                                      \
+} while (0)
+
+#define CHECK_EQ_U(a, b) do {                                             \
+   uint64_t _a = (uint64_t)(a), _b = (uint64_t)(b);                       \
+   tests_run++;                                                           \
+   if (_a != _b) {                                                        \
+      tests_failed++;                                                     \
+      fprintf(stderr, "FAIL %s:%d: %s (=%llx) != %s (=%llx)\n",           \
+              __FILE__, __LINE__, #a,                                     \
+              (unsigned long long)_a, #b, (unsigned long long)_b);        \
+   }                                                                      \
+} while (0)
+
+/* --------------------------------------------------------------------- */
+/* 1. Parser                                                              */
+/* --------------------------------------------------------------------- */
+
+static void test_parse_valid_formats(void)
+{
+   uint32_t addr, val;
+   uint8_t  size;
+
+   /* 6+2: short address + byte */
+   CHECK(cheat_parse_one("F03200 7F", &addr, &val, &size));
+   CHECK_EQ_U(addr, 0xF03200u);
+   CHECK_EQ_U(val,  0x7Fu);
+   CHECK_EQ_U(size, 1u);
+
+   /* 6+4: short address + word */
+   CHECK(cheat_parse_one("003D00:FFFF", &addr, &val, &size));
+   CHECK_EQ_U(addr, 0x003D00u);
+   CHECK_EQ_U(val,  0xFFFFu);
+   CHECK_EQ_U(size, 2u);
+
+   /* 8+4: full address + word (Pro Action Replay canonical) */
+   CHECK(cheat_parse_one("00003D00 FFFF", &addr, &val, &size));
+   CHECK_EQ_U(addr, 0x003D00u);        /* masked to 24 bits */
+   CHECK_EQ_U(val,  0xFFFFu);
+   CHECK_EQ_U(size, 2u);
+
+   /* 6+8: short address + long */
+   CHECK(cheat_parse_one("100000 CAFEBABE", &addr, &val, &size));
+   CHECK_EQ_U(addr, 0x100000u);
+   CHECK_EQ_U(val,  0xCAFEBABEu);
+   CHECK_EQ_U(size, 4u);
+
+   /* 8+8: full address + long */
+   CHECK(cheat_parse_one("00100000-DEADBEEF", &addr, &val, &size));
+   CHECK_EQ_U(addr, 0x100000u);
+   CHECK_EQ_U(val,  0xDEADBEEFu);
+   CHECK_EQ_U(size, 4u);
+
+   /* 8+2: full address + byte — boundary via space or last ':', '-', '.' */
+   CHECK(cheat_parse_one("00003D00 FF", &addr, &val, &size));
+   CHECK_EQ_U(addr, 0x003D00u);
+   CHECK_EQ_U(val,  0xFFu);
+   CHECK_EQ_U(size, 1u);
+
+   CHECK(cheat_parse_one("00003D00:FF", &addr, &val, &size));
+   CHECK_EQ_U(addr, 0x003D00u);
+   CHECK_EQ_U(val,  0xFFu);
+   CHECK_EQ_U(size, 1u);
+
+   CHECK(cheat_parse_one("0000:3D00:FF", &addr, &val, &size));
+   CHECK_EQ_U(addr, 0x003D00u);
+   CHECK_EQ_U(val,  0xFFu);
+   CHECK_EQ_U(size, 1u);
+}
+
+static void test_parse_separators(void)
+{
+   uint32_t addr, val;
+   uint8_t  size;
+
+   /* All of these must yield the same result. */
+   const char *equivalents[] = {
+      "00003D00 FFFF",
+      "00003D00:FFFF",
+      "00003D00-FFFF",
+      "00003D00.FFFF",
+      "00003D00FFFF",
+      "0000:3D00-FFFF",
+      "00 00 3D 00 FF FF",
+      "  00003D00   FFFF  ",
+      NULL
+   };
+   size_t i;
+   for (i = 0; equivalents[i]; i++)
+   {
+      CHECK(cheat_parse_one(equivalents[i], &addr, &val, &size));
+      CHECK_EQ_U(addr, 0x003D00u);
+      CHECK_EQ_U(val,  0xFFFFu);
+      CHECK_EQ_U(size, 2u);
+   }
+}
+
+static void test_parse_case_insensitive(void)
+{
+   uint32_t addr, val;
+   uint8_t  size;
+   CHECK(cheat_parse_one("abcdef 12", &addr, &val, &size));
+   CHECK_EQ_U(addr, 0xABCDEFu);
+   CHECK_EQ_U(val,  0x12u);
+   CHECK(cheat_parse_one("ABCDEF 12", &addr, &val, &size));
+   CHECK_EQ_U(addr, 0xABCDEFu);
+   CHECK(cheat_parse_one("AbCdEf 12", &addr, &val, &size));
+   CHECK_EQ_U(addr, 0xABCDEFu);
+}
+
+static void test_parse_address_masked_to_24_bits(void)
+{
+   uint32_t addr, val;
+   uint8_t  size;
+   /* Pro Action Replay codes sometimes carry a high byte encoding
+    * region/metadata. We strip it — only the 24-bit bus address matters. */
+   CHECK(cheat_parse_one("FF003D00 FFFF", &addr, &val, &size));
+   CHECK_EQ_U(addr, 0x003D00u);
+}
+
+static void test_parse_invalid(void)
+{
+   uint32_t addr = 0xdeadbeef, val = 0xdeadbeef;
+   uint8_t  size = 99;
+
+   /* NULL inputs */
+   CHECK(!cheat_parse_one(NULL,      &addr, &val, &size));
+   CHECK(!cheat_parse_one("00 11",    NULL, &val, &size));
+   CHECK(!cheat_parse_one("00 11",   &addr,  NULL, &size));
+   CHECK(!cheat_parse_one("00 11",   &addr, &val,   NULL));
+
+   /* Wrong total length (all other lengths must fail) */
+   CHECK(!cheat_parse_one("",                          &addr, &val, &size));
+   CHECK(!cheat_parse_one("12",                        &addr, &val, &size));
+   CHECK(!cheat_parse_one("1234",                      &addr, &val, &size));
+   CHECK(!cheat_parse_one("123456",                    &addr, &val, &size)); /* addr only */
+   CHECK(!cheat_parse_one("1234567",                   &addr, &val, &size)); /* 7 digits */
+   CHECK(!cheat_parse_one("123456789",                 &addr, &val, &size)); /* 9 digits */
+   CHECK(!cheat_parse_one("12345678 1",                &addr, &val, &size)); /* 9 digits */
+   CHECK(!cheat_parse_one("12345678 123",              &addr, &val, &size)); /* 11 digits */
+   CHECK(!cheat_parse_one("12345678 12345",            &addr, &val, &size)); /* 13 */
+   CHECK(!cheat_parse_one("12345678 1234567",          &addr, &val, &size)); /* 15 */
+   CHECK(!cheat_parse_one("12345678 123456789",        &addr, &val, &size)); /* 17 */
+
+   /* Bad characters */
+   CHECK(!cheat_parse_one("GGGGGG 12",                 &addr, &val, &size));
+   CHECK(!cheat_parse_one("00003D00 FFFG",             &addr, &val, &size));
+   CHECK(!cheat_parse_one("00003D00/FFFF",             &addr, &val, &size));
+   CHECK(!cheat_parse_one("00003D00,FFFF",             &addr, &val, &size));
+
+   /* More than 16 hex digits (longest valid single code is 8+8). */
+   CHECK(!cheat_parse_one("00003D00FFFFFFFF1",         &addr, &val, &size));
+}
+
+/* --------------------------------------------------------------------- */
+/* 2. List management                                                     */
+/* --------------------------------------------------------------------- */
+
+static void test_list_add_and_remove(void)
+{
+   cheat_list_t list;
+   cheat_list_reset(&list);
+   CHECK_EQ_U(list.count, 0u);
+
+   cheat_list_set(&list, 0, true, "00003D00 FFFF");
+   CHECK_EQ_U(list.count, 1u);
+   CHECK_EQ_U(list.entries[0].address, 0x003D00u);
+   CHECK_EQ_U(list.entries[0].value,   0xFFFFu);
+   CHECK_EQ_U(list.entries[0].size,    2u);
+   CHECK_EQ_U(list.entries[0].tag,     0u);
+   CHECK(list.entries[0].enabled);
+
+   cheat_list_set(&list, 1, true, "100000 BEEF");
+   CHECK_EQ_U(list.count, 2u);
+
+   /* Disable index 0 — must remove the first entry only. */
+   cheat_list_set(&list, 0, false, "");
+   CHECK_EQ_U(list.count, 1u);
+   CHECK_EQ_U(list.entries[0].address, 0x100000u);
+   CHECK_EQ_U(list.entries[0].tag,     1u);
+
+   /* enabled=false must clear the slot even when code is NULL. */
+   cheat_list_set(&list, 1, false, NULL);
+   CHECK_EQ_U(list.count, 0u);
+
+   cheat_list_reset(&list);
+}
+
+static void test_list_index_not_truncated(void)
+{
+   cheat_list_t list;
+   cheat_list_reset(&list);
+   cheat_list_set(&list, 0, true, "001000 7F");
+   cheat_list_set(&list, 256, true, "002000 AB");
+   CHECK_EQ_U(list.count, 2u);
+   cheat_list_set(&list, 256, false, NULL);
+   CHECK_EQ_U(list.count, 1u);
+   CHECK_EQ_U(list.entries[0].tag, 0u);
+
+   cheat_list_reset(&list);
+   CHECK_EQ_U(list.count, 0u);
+}
+
+static void test_list_replace_same_index(void)
+{
+   cheat_list_t list;
+   cheat_list_reset(&list);
+
+   cheat_list_set(&list, 5, true, "00003D00 FFFF");
+   cheat_list_set(&list, 5, true, "00100000 CAFE"); /* replace */
+   CHECK_EQ_U(list.count, 1u);
+   CHECK_EQ_U(list.entries[0].address, 0x100000u);
+   CHECK_EQ_U(list.entries[0].value,   0xCAFEu);
+}
+
+static void test_list_multi_code_string(void)
+{
+   cheat_list_t list;
+   cheat_list_reset(&list);
+
+   /* '+' and newline as separators — this mirrors multi-line .cht codes. */
+   cheat_list_set(&list, 3, true,
+                  "00003D00 FFFF+"
+                  "00100000 BEEF\n"
+                  "00200000 CAFEBABE");
+   CHECK_EQ_U(list.count, 3u);
+   CHECK_EQ_U(list.entries[0].address, 0x003D00u);
+   CHECK_EQ_U(list.entries[0].size,    2u);
+   CHECK_EQ_U(list.entries[1].address, 0x100000u);
+   CHECK_EQ_U(list.entries[1].value,   0xBEEFu);
+   CHECK_EQ_U(list.entries[2].address, 0x200000u);
+   CHECK_EQ_U(list.entries[2].size,    4u);
+   CHECK_EQ_U(list.entries[2].value,   0xCAFEBABEu);
+
+   /* Toggling the group off removes all three. */
+   cheat_list_set(&list, 3, false, "");
+   CHECK_EQ_U(list.count, 0u);
+}
+
+static void test_list_skips_malformed_entries(void)
+{
+   cheat_list_t list;
+   cheat_list_reset(&list);
+
+   /* Middle entry is garbage — the valid ones before and after must remain. */
+   cheat_list_set(&list, 0, true,
+                  "00003D00 FFFF+"
+                  "garbage+"
+                  "00100000 BEEF");
+   CHECK_EQ_U(list.count, 2u);
+   CHECK_EQ_U(list.entries[0].address, 0x003D00u);
+   CHECK_EQ_U(list.entries[1].address, 0x100000u);
+}
+
+static void test_list_capacity(void)
+{
+   cheat_list_t list;
+   unsigned i;
+   cheat_list_reset(&list);
+   /* Fill with distinct cheat indices until the list hits CHEAT_MAX_ENTRIES. */
+   for (i = 0; i < CHEAT_MAX_ENTRIES + 50; i++)
+   {
+      char code[32];
+      snprintf(code, sizeof(code), "%06X FF", i);
+      cheat_list_set(&list, i, true, code);
+   }
+   CHECK(list.count <= CHEAT_MAX_ENTRIES);
+}
+
+/* --------------------------------------------------------------------- */
+/* 3. Application to simulated memory                                     */
+/* --------------------------------------------------------------------- */
+
+/* 16 MB simulated Jaguar-sized address space. Big-endian writes match
+ * the real emulator, which targets a big-endian bus. */
+#define SIM_MEM_SIZE (16 * 1024 * 1024)
+static uint8_t sim_mem[SIM_MEM_SIZE];
+
+static void sim_write(uint32_t addr, uint32_t value, uint8_t size, void *user)
+{
+   (void)user;
+   addr &= 0x00FFFFFF;
+   /* 24-bit bus: last in-range long write starts at 0xFFFFFC; word at 0xFFFFFE. */
+   if ((size_t)addr + (size_t)size > (size_t)SIM_MEM_SIZE)
+      return;
+   switch (size)
+   {
+      case 1:
+         sim_mem[addr] = (uint8_t)(value & 0xFF);
+         break;
+      case 2:
+         sim_mem[addr]     = (uint8_t)((value >> 8) & 0xFF);
+         sim_mem[addr + 1] = (uint8_t)(value       & 0xFF);
+         break;
+      case 4:
+         sim_mem[addr]     = (uint8_t)((value >> 24) & 0xFF);
+         sim_mem[addr + 1] = (uint8_t)((value >> 16) & 0xFF);
+         sim_mem[addr + 2] = (uint8_t)((value >>  8) & 0xFF);
+         sim_mem[addr + 3] = (uint8_t)(value         & 0xFF);
+         break;
+   }
+}
+
+static uint16_t sim_read16(uint32_t addr)
+{
+   addr &= 0x00FFFFFF;
+   if ((size_t)addr + 2u > (size_t)SIM_MEM_SIZE)
+      return 0;
+   return (uint16_t)((sim_mem[addr] << 8) | sim_mem[addr + 1]);
+}
+
+static uint32_t sim_read32(uint32_t addr)
+{
+   addr &= 0x00FFFFFF;
+   if ((size_t)addr + 4u > (size_t)SIM_MEM_SIZE)
+      return 0;
+   return ((uint32_t)sim_mem[addr]     << 24) |
+          ((uint32_t)sim_mem[addr + 1] << 16) |
+          ((uint32_t)sim_mem[addr + 2] <<  8) |
+           (uint32_t)sim_mem[addr + 3];
+}
+
+static void test_apply_byte_word_long(void)
+{
+   cheat_list_t list;
+   memset(sim_mem, 0, sizeof(sim_mem));
+   cheat_list_reset(&list);
+
+   cheat_list_set(&list, 0, true, "001000 7F");        /* byte */
+   cheat_list_set(&list, 1, true, "002000 ABCD");      /* word */
+   cheat_list_set(&list, 2, true, "003000 DEADBEEF");  /* long */
+
+   cheat_list_apply(&list, sim_write, NULL);
+
+   CHECK_EQ_U(sim_mem[0x001000],  0x7Fu);
+   CHECK_EQ_U(sim_read16(0x002000), 0xABCDu);
+   CHECK_EQ_U(sim_read32(0x003000), 0xDEADBEEFu);
+}
+
+static void test_apply_disabled_not_written(void)
+{
+   cheat_list_t list;
+   memset(sim_mem, 0, sizeof(sim_mem));
+   cheat_list_reset(&list);
+
+   cheat_list_set(&list, 0, true, "001000 FF");
+   cheat_list_apply(&list, sim_write, NULL);
+   CHECK_EQ_U(sim_mem[0x001000], 0xFFu);
+
+   /* Disable it and wipe the location; re-apply must NOT touch it. */
+   cheat_list_set(&list, 0, false, "");
+   sim_mem[0x001000] = 0x00;
+   cheat_list_apply(&list, sim_write, NULL);
+   CHECK_EQ_U(sim_mem[0x001000], 0x00u);
+}
+
+/* --------------------------------------------------------------------- */
+/* 4. End-to-end simulation ("fake ROM" that fights the cheat)            */
+/* --------------------------------------------------------------------- */
+
+/* Simulates the real-world situation where a running game writes a
+ * value (e.g. current lives) to RAM every frame. Without a cheat, the
+ * location holds whatever the "CPU" last wrote. With an infinite-lives
+ * cheat applied after each frame, the patched value must win. */
+static void fake_cpu_frame(uint32_t addr, uint8_t game_value)
+{
+   sim_mem[addr] = game_value;
+}
+
+static void test_end_to_end_frame_loop(void)
+{
+   cheat_list_t list;
+   const uint32_t lives_addr = 0x00ABCD;
+   int frame;
+
+   memset(sim_mem, 0, sizeof(sim_mem));
+   cheat_list_reset(&list);
+
+   /* Without a cheat, the fake CPU decrements lives every frame. */
+   for (frame = 5; frame >= 0; frame--)
+   {
+      fake_cpu_frame(lives_addr, (uint8_t)frame);
+      cheat_list_apply(&list, sim_write, NULL); /* no-op: list empty */
+   }
+   CHECK_EQ_U(sim_mem[lives_addr], 0u);
+
+   /* Now install an infinite-lives cheat: every frame, after the game
+    * writes the "real" value, we clobber it back to 9. */
+   cheat_list_set(&list, 0, true, "00ABCD 09");
+   for (frame = 5; frame >= 0; frame--)
+   {
+      fake_cpu_frame(lives_addr, (uint8_t)frame);
+      cheat_list_apply(&list, sim_write, NULL);
+      CHECK_EQ_U(sim_mem[lives_addr], 9u);
+   }
+}
+
+/* --------------------------------------------------------------------- */
+/* 5. Real-world-shaped examples                                          */
+/* --------------------------------------------------------------------- */
+
+/* These are the sorts of codes a user copy-pastes from a cheat database
+ * into the RetroArch cheat editor. We don't ship any game-specific cheat
+ * database (for licensing reasons), but the parser must accept the forms
+ * they're published in. */
+static void test_real_world_shapes(void)
+{
+   uint32_t addr, val;
+   uint8_t  size;
+
+   /* Typical "infinite lives" style — PAR canonical form. */
+   CHECK(cheat_parse_one("00004ACC 0009", &addr, &val, &size));
+   CHECK_EQ_U(size, 2u);
+
+   /* Colon-separated 24-bit, byte value (common on homebrew docs). */
+   CHECK(cheat_parse_one("004ACC:09", &addr, &val, &size));
+   CHECK_EQ_U(addr, 0x004ACCu);
+   CHECK_EQ_U(val,  0x09u);
+   CHECK_EQ_U(size, 1u);
+
+   /* Long-value patch — e.g. replacing a jump instruction (pair of words). */
+   CHECK(cheat_parse_one("00102030 4E714E71", &addr, &val, &size));
+   CHECK_EQ_U(addr, 0x102030u);
+   CHECK_EQ_U(val,  0x4E714E71u);   /* two NOPs */
+   CHECK_EQ_U(size, 4u);
+}
+
+/* --------------------------------------------------------------------- */
+
+int main(void)
+{
+   test_parse_valid_formats();
+   test_parse_separators();
+   test_parse_case_insensitive();
+   test_parse_address_masked_to_24_bits();
+   test_parse_invalid();
+
+   test_list_add_and_remove();
+   test_list_index_not_truncated();
+   test_list_replace_same_index();
+   test_list_multi_code_string();
+   test_list_skips_malformed_entries();
+   test_list_capacity();
+
+   test_apply_byte_word_long();
+   test_apply_disabled_not_written();
+
+   test_end_to_end_frame_loop();
+   test_real_world_shapes();
+
+   printf("cheat tests: %d run, %d failed\n", tests_run, tests_failed);
+   return tests_failed == 0 ? 0 : 1;
+}

--- a/test/test_dsp_mac40.c
+++ b/test/test_dsp_mac40.c
@@ -1,0 +1,56 @@
+/*
+ * Unit tests for src/dsp_acc40.h (Jaguar DSP 40-bit MAC semantics).
+ * Build: cc -O2 -Wall -I../src -o test_dsp_mac40 test/test_dsp_mac40.c
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "dsp_acc40.h"
+
+int main(void)
+{
+	uint64_t acc;
+	int i;
+	int failed = 0;
+
+	/* Only 40 physical bits; high 24 must stay clear */
+	acc = 0;
+	for (i = 0; i < 50000; i++)
+		dsp_acc_mac_apply(&acc, 7777);
+	if (acc & ~(DSP_ACC_U40_MASK))
+	{
+		fprintf(stderr, "FAIL: bits above 39 set after MAC loop (acc=%llx)\n",
+				(unsigned long long)acc);
+		failed++;
+	}
+
+	/* RESMAC-style low 32 must be stable across wraps */
+	acc = DSP_ACC_U40_MASK;
+	dsp_acc_mac_apply(&acc, 1);
+	if ((uint32_t)acc != 0)
+	{
+		fprintf(stderr, "FAIL: wrap +1 from 40-bit all-ones (got low32=%x)\n",
+				(unsigned int)(uint32_t)acc);
+		failed++;
+	}
+
+	/* Load int32 -1 into acc (sign-extended in 40-bit domain) */
+	dsp_acc_set_from_i32(&acc, -1);
+	if (acc != DSP_ACC_U40_MASK)
+	{
+		fprintf(stderr, "FAIL: set -1 (acc=%llx expected %llx)\n",
+				(unsigned long long)acc, (unsigned long long)DSP_ACC_U40_MASK);
+		failed++;
+	}
+
+	if (failed)
+	{
+		fprintf(stderr, "test_dsp_mac40: %d failure(s)\n", failed);
+		return 1;
+	}
+
+	printf("test_dsp_mac40: OK\n");
+	return 0;
+}

--- a/test/tools/build_rcheevos_static.sh
+++ b/test/tools/build_rcheevos_static.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Builds a static librcheevos.a from the official RetroAchievements/rcheevos repo.
+# Used by test_rcheevos_e2e.sh. Pin RCHEEVOS_REF to a tag or full commit SHA.
+# Tarball URL: https://github.com/RetroAchievements/rcheevos/archive/${REF}.tar.gz
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DEST="${DEST:-$ROOT/build/rcheevos-static}"
+REF="${RCHEEVOS_REF:-v12.3.0}"
+CC="${CC:-cc}"
+
+mkdir -p "$DEST"
+
+CACHE_MARK="$DEST/.extracted_${REF//\//_}"
+
+if [[ ! -f "$CACHE_MARK" ]]; then
+   rm -rf "${DEST:?}/"* "${DEST:?}/".extracted_* 2>/dev/null || true
+   TMP="$DEST/dl"
+   mkdir -p "$TMP"
+   echo "Downloading rcheevos ${REF}..."
+   curl -fsSL -o "$TMP/rc.tgz" "https://github.com/RetroAchievements/rcheevos/archive/${REF}.tar.gz"
+   tar -xzf "$TMP/rc.tgz" -C "$DEST"
+   rm -rf "$TMP"
+   SRC="$(echo "$DEST"/rcheevos-* | head -1)"
+   mv "$SRC" "$DEST/rcheevos-src"
+   touch "$CACHE_MARK"
+fi
+
+SRCROOT="$DEST/rcheevos-src"
+OBJDIR="$DEST/obj"
+rm -rf "$OBJDIR"
+mkdir -p "$OBJDIR"
+
+CFLAGS="-O2 -I${SRCROOT}/include -I${SRCROOT}/src -I${ROOT}/libretro-common/include -DRC_DISABLE_LUA -DRC_CLIENT_SUPPORTS_HASH"
+
+echo "Compiling rcheevos sources..."
+while IFS= read -r -d '' f; do
+   bn="$(basename "$f" .c)"
+   $CC -c $CFLAGS -o "$OBJDIR/${bn}.o" "$f"
+done < <(find "$SRCROOT/src" -name '*.c' -print0)
+
+ar rcs "$DEST/librcheevos.a" "$OBJDIR"/*.o
+echo "Built $DEST/librcheevos.a"

--- a/test/tools/test_memory_map.c
+++ b/test/tools/test_memory_map.c
@@ -1,0 +1,350 @@
+/*
+ * test_memory_map.c — Verify RetroAchievements memory map advertisement.
+ *
+ * Loads the core, feeds a minimal dummy ROM, and checks that
+ * RETRO_ENVIRONMENT_SET_MEMORY_MAPS is advertised and SET_SUPPORT_ACHIEVEMENTS
+ * is called with a non-NULL pointer to bool true (per libretro.h).
+ *
+ * Build:
+ *   cc -o test/tools/test_memory_map test/tools/test_memory_map.c -ldl  (Linux)
+ *   cc -o test/tools/test_memory_map test/tools/test_memory_map.c       (macOS)
+ *
+ * Usage:
+ *   ./test/tools/test_memory_map <core.dylib|so>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __APPLE__
+#include <dlfcn.h>
+#define LIBEXT "dylib"
+#else
+#include <dlfcn.h>
+#define LIBEXT "so"
+#endif
+
+#include "../../libretro-common/include/libretro.h"
+
+typedef void   (*retro_init_t)(void);
+typedef void   (*retro_deinit_t)(void);
+typedef void   (*retro_set_environment_t)(retro_environment_t);
+typedef void   (*retro_set_video_refresh_t)(retro_video_refresh_t);
+typedef void   (*retro_set_audio_sample_t)(retro_audio_sample_t);
+typedef void   (*retro_set_audio_sample_batch_t)(retro_audio_sample_batch_t);
+typedef void   (*retro_set_input_poll_t)(retro_input_poll_t);
+typedef void   (*retro_set_input_state_t)(retro_input_state_t);
+typedef bool   (*retro_load_game_t)(const struct retro_game_info *);
+typedef void   (*retro_unload_game_t)(void);
+typedef void  *(*retro_get_memory_data_t)(unsigned);
+typedef size_t (*retro_get_memory_size_t)(unsigned);
+
+static bool got_memory_maps;
+static bool got_achievements;
+static bool achievements_data_ok;
+static bool achievements_enabled_true;
+static const struct retro_memory_map *captured_memmap;
+
+static bool env_cb(unsigned cmd, void *data)
+{
+    switch (cmd)
+    {
+    case RETRO_ENVIRONMENT_SET_MEMORY_MAPS:
+        got_memory_maps = true;
+        captured_memmap = (const struct retro_memory_map *)data;
+        return true;
+    case RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS:
+        got_achievements = true;
+        if (data)
+        {
+            achievements_data_ok = true;
+            achievements_enabled_true = *(const bool *)data;
+        }
+        return true;
+    case RETRO_ENVIRONMENT_SET_PIXEL_FORMAT:
+    case RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME:
+        return true;
+    case RETRO_ENVIRONMENT_GET_VARIABLE:
+        return false;
+    case RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE:
+        if (data) *(bool *)data = false;
+        return true;
+    case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY:
+    case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY:
+        if (data) *(const char **)data = ".";
+        return true;
+    case RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION:
+        if (data) *(unsigned *)data = 0;
+        return true;
+    case RETRO_ENVIRONMENT_GET_INPUT_BITMASKS:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static void video_cb(const void *d, unsigned w, unsigned h, size_t p)
+{ (void)d; (void)w; (void)h; (void)p; }
+static void audio_cb(int16_t l, int16_t r)
+{ (void)l; (void)r; }
+static size_t audio_batch(const int16_t *d, size_t f)
+{ (void)d; return f; }
+static void input_poll(void) {}
+static int16_t input_state(unsigned p, unsigned d, unsigned i, unsigned id)
+{ (void)p; (void)d; (void)i; (void)id; return 0; }
+
+static void *load_sym(void *handle, const char *name)
+{
+    void *sym = dlsym(handle, name);
+    if (!sym)
+    {
+        fprintf(stderr, "ERROR: Missing symbol: %s\n", name);
+        exit(1);
+    }
+    return sym;
+}
+
+/*
+ * Build a minimal 8 KB Jaguar ROM with a valid header.
+ * The ROM header at 0x400 sets the entry point at 0x802000.
+ * We place an infinite loop (BRA.S $802000) at the entry point.
+ */
+static uint8_t *make_dummy_rom(size_t *size_out)
+{
+    /* 0x2000 bytes is not enough: we patch instructions at file offset 0x2000 (8 KiB). */
+    size_t sz = 12288;
+    uint8_t *rom = calloc(1, sz);
+    if (!rom) { perror("calloc"); exit(1); }
+
+    /* Jaguar ROM header at offset 0x400 */
+    /* 0x404: run address (big-endian) = 0x00802000 */
+    rom[0x404] = 0x00; rom[0x405] = 0x80;
+    rom[0x406] = 0x20; rom[0x407] = 0x00;
+
+    /* At offset 0x2000 (maps to 0x802000): BRA.S self (0x60FE) */
+    rom[0x2000] = 0x60; rom[0x2001] = 0xFE;
+
+    *size_out = sz;
+    return rom;
+}
+
+int main(int argc, char **argv)
+{
+    void *handle;
+    retro_init_t                core_init;
+    retro_deinit_t              core_deinit;
+    retro_set_environment_t     core_set_env;
+    retro_set_video_refresh_t   core_set_video;
+    retro_set_audio_sample_t    core_set_audio;
+    retro_set_audio_sample_batch_t core_set_audio_batch;
+    retro_set_input_poll_t      core_set_input_poll;
+    retro_set_input_state_t     core_set_input_state;
+    retro_load_game_t           core_load_game;
+    retro_unload_game_t         core_unload_game;
+    retro_get_memory_data_t     core_get_memory_data;
+    retro_get_memory_size_t     core_get_memory_size;
+    struct retro_game_info info;
+    uint8_t *rom;
+    size_t rom_size;
+    int failures = 0;
+
+    if (argc < 2)
+    {
+        fprintf(stderr, "Usage: %s <core." LIBEXT ">\n", argv[0]);
+        return 1;
+    }
+
+    handle = dlopen(argv[1], RTLD_LAZY);
+    if (!handle) { fprintf(stderr, "dlopen: %s\n", dlerror()); return 1; }
+
+    core_init             = (retro_init_t)load_sym(handle, "retro_init");
+    core_deinit           = (retro_deinit_t)load_sym(handle, "retro_deinit");
+    core_set_env          = (retro_set_environment_t)load_sym(handle, "retro_set_environment");
+    core_set_video        = (retro_set_video_refresh_t)load_sym(handle, "retro_set_video_refresh");
+    core_set_audio        = (retro_set_audio_sample_t)load_sym(handle, "retro_set_audio_sample");
+    core_set_audio_batch  = (retro_set_audio_sample_batch_t)load_sym(handle, "retro_set_audio_sample_batch");
+    core_set_input_poll   = (retro_set_input_poll_t)load_sym(handle, "retro_set_input_poll");
+    core_set_input_state  = (retro_set_input_state_t)load_sym(handle, "retro_set_input_state");
+    core_load_game        = (retro_load_game_t)load_sym(handle, "retro_load_game");
+    core_unload_game      = (retro_unload_game_t)load_sym(handle, "retro_unload_game");
+    core_get_memory_data  = (retro_get_memory_data_t)load_sym(handle, "retro_get_memory_data");
+    core_get_memory_size  = (retro_get_memory_size_t)load_sym(handle, "retro_get_memory_size");
+
+    got_memory_maps = false;
+    got_achievements = false;
+    achievements_data_ok = false;
+    achievements_enabled_true = false;
+    captured_memmap = NULL;
+
+    core_set_env(env_cb);
+
+    /* Test 1: must fire from retro_set_environment before retro_init (not after init) */
+    printf("Test 1: SET_SUPPORT_ACHIEVEMENTS (true) ... ");
+    if (got_achievements && achievements_data_ok && achievements_enabled_true)
+        printf("PASS\n");
+    else if (!got_achievements)
+    {
+        printf("FAIL (not called during retro_set_environment)\n");
+        failures++;
+    }
+    else if (!achievements_data_ok)
+    {
+        printf("FAIL (NULL data)\n");
+        failures++;
+    }
+    else
+    {
+        printf("FAIL (expected true, got false)\n");
+        failures++;
+    }
+
+    core_set_video(video_cb);
+    core_set_audio(audio_cb);
+    core_set_audio_batch(audio_batch);
+    core_set_input_poll(input_poll);
+    core_set_input_state(input_state);
+    core_init();
+
+    /* Load the dummy ROM to trigger SET_MEMORY_MAPS */
+    rom = make_dummy_rom(&rom_size);
+    memset(&info, 0, sizeof(info));
+    info.path = "dummy.j64";
+    info.data = rom;
+    info.size = rom_size;
+
+    if (!core_load_game(&info))
+    {
+        fprintf(stderr, "ERROR: retro_load_game returned false\n");
+        free(rom);
+        core_deinit();
+        dlclose(handle);
+        return 1;
+    }
+
+    /* Test 2: SET_MEMORY_MAPS called during retro_load_game */
+    printf("Test 2: SET_MEMORY_MAPS called ... ");
+    if (got_memory_maps)
+        printf("PASS\n");
+    else
+    {
+        printf("FAIL (not called)\n");
+        failures++;
+    }
+
+    /* Test 3: Memory map has exactly 1 descriptor */
+    printf("Test 3: num_descriptors == 1 ... ");
+    if (captured_memmap && captured_memmap->num_descriptors == 1)
+    {
+        if (captured_memmap->descriptors != NULL)
+            printf("PASS\n");
+        else
+        {
+            printf("FAIL (descriptors is NULL)\n");
+            failures++;
+        }
+    }
+    else
+    {
+        printf("FAIL (got %u)\n",
+               captured_memmap ? (unsigned)captured_memmap->num_descriptors : 0);
+        failures++;
+    }
+
+    /* Tests 4–9: descriptor [0] (requires non-NULL descriptors table) */
+    if (!captured_memmap || captured_memmap->num_descriptors < 1)
+    {
+        printf("Tests 4-9: SKIPPED (no descriptor)\n");
+        failures += 6;
+    }
+    else if (!captured_memmap->descriptors)
+    {
+        printf("Tests 4-9: FAIL (descriptors is NULL)\n");
+        failures += 6;
+    }
+    else
+    {
+        const struct retro_memory_descriptor *d = &captured_memmap->descriptors[0];
+
+        printf("Test 4: descriptor start == 0x000000 ... ");
+        if (d->start == 0x000000)
+            printf("PASS\n");
+        else
+        {
+            printf("FAIL (0x%06zx)\n", d->start);
+            failures++;
+        }
+
+        printf("Test 5: descriptor len == 0x200000 ... ");
+        if (d->len == 0x200000)
+            printf("PASS\n");
+        else
+        {
+            printf("FAIL (0x%06zx)\n", d->len);
+            failures++;
+        }
+
+        printf("Test 6: RETRO_MEMDESC_SYSTEM_RAM flag set ... ");
+        if (d->flags & RETRO_MEMDESC_SYSTEM_RAM)
+            printf("PASS\n");
+        else
+        {
+            printf("FAIL (flags=0x%llx)\n", (unsigned long long)d->flags);
+            failures++;
+        }
+
+        printf("Test 7: RETRO_MEMDESC_BIGENDIAN flag set ... ");
+        if (d->flags & RETRO_MEMDESC_BIGENDIAN)
+            printf("PASS\n");
+        else
+        {
+            printf("FAIL (flags=0x%llx)\n", (unsigned long long)d->flags);
+            failures++;
+        }
+
+        printf("Test 8: descriptor ptr is non-NULL ... ");
+        if (d->ptr != NULL)
+            printf("PASS\n");
+        else
+        {
+            printf("FAIL\n");
+            failures++;
+        }
+
+        printf("Test 9: descriptor ptr matches retro_get_memory_data(SYSTEM_RAM) ... ");
+        {
+            void *sysram = core_get_memory_data(RETRO_MEMORY_SYSTEM_RAM);
+            if (d->ptr == sysram)
+                printf("PASS\n");
+            else
+            {
+                printf("FAIL (map=%p, get_memory=%p)\n", d->ptr, sysram);
+                failures++;
+            }
+        }
+    }
+
+    /* Test 10: retro_get_memory_size(SYSTEM_RAM) == 0x200000 */
+    printf("Test 10: retro_get_memory_size(SYSTEM_RAM) == 0x200000 ... ");
+    {
+        size_t sz = core_get_memory_size(RETRO_MEMORY_SYSTEM_RAM);
+        if (sz == 0x200000)
+            printf("PASS\n");
+        else
+        {
+            printf("FAIL (0x%zx)\n", sz);
+            failures++;
+        }
+    }
+
+    core_unload_game();
+    core_deinit();
+    free(rom);
+    dlclose(handle);
+
+    printf("\n%s: %d test(s) failed.\n",
+           failures ? "FAIL" : "OK", failures);
+    return failures ? 1 : 0;
+}

--- a/test/tools/test_rcheevos_e2e.c
+++ b/test/tools/test_rcheevos_e2e.c
@@ -1,0 +1,295 @@
+/*
+ * test_rcheevos_e2e.c — Load Virtual Jaguar, feed rcheevos rc_libretro with the same
+ * SET_MEMORY_MAPS descriptor RetroArch receives, then verify address resolution matches
+ * host RAM (offline; no RetroAchievements server).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <dlfcn.h>
+
+#include "../../libretro-common/include/libretro.h"
+#include "rc_libretro.h"
+#include "rc_consoles.h"
+
+typedef void   (*retro_init_t)(void);
+typedef void   (*retro_deinit_t)(void);
+typedef void   (*retro_set_environment_t)(retro_environment_t);
+typedef void   (*retro_set_video_refresh_t)(retro_video_refresh_t);
+typedef void   (*retro_set_audio_sample_t)(retro_audio_sample_t);
+typedef void   (*retro_set_audio_sample_batch_t)(retro_audio_sample_batch_t);
+typedef void   (*retro_set_input_poll_t)(retro_input_poll_t);
+typedef void   (*retro_set_input_state_t)(retro_input_state_t);
+typedef bool   (*retro_load_game_t)(const struct retro_game_info *);
+typedef void   (*retro_unload_game_t)(void);
+typedef void  *(*retro_get_memory_data_t)(unsigned);
+typedef size_t (*retro_get_memory_size_t)(unsigned);
+
+static const struct retro_memory_map *g_mmap;
+static retro_get_memory_data_t g_get_memory_data;
+static retro_get_memory_size_t g_get_memory_size;
+
+static bool env_cb(unsigned cmd, void *data)
+{
+    switch (cmd)
+    {
+    case RETRO_ENVIRONMENT_SET_MEMORY_MAPS:
+        g_mmap = (const struct retro_memory_map *)data;
+        return true;
+    case RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS:
+        return true;
+    case RETRO_ENVIRONMENT_SET_PIXEL_FORMAT:
+    case RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME:
+        return true;
+    case RETRO_ENVIRONMENT_GET_VARIABLE:
+        return false;
+    case RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE:
+        if (data) *(bool *)data = false;
+        return true;
+    case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY:
+    case RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY:
+        if (data) *(const char **)data = ".";
+        return true;
+    case RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION:
+        if (data) *(unsigned *)data = 0;
+        return true;
+    case RETRO_ENVIRONMENT_GET_INPUT_BITMASKS:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static void libretro_get_core_memory_info(uint32_t id, rc_libretro_core_memory_info_t *info)
+{
+    if (!g_get_memory_data || !g_get_memory_size)
+    {
+        info->data = NULL;
+        info->size = 0;
+        return;
+    }
+    info->data = (uint8_t *)g_get_memory_data(id);
+    info->size = g_get_memory_size(id);
+}
+
+static void video_cb(const void *d, unsigned w, unsigned h, size_t p)
+{ (void)d; (void)w; (void)h; (void)p; }
+static void audio_cb(int16_t l, int16_t r)
+{ (void)l; (void)r; }
+static size_t audio_batch(const int16_t *d, size_t f)
+{ (void)d; return f; }
+static void input_poll(void) {}
+static int16_t input_state(unsigned p, unsigned d, unsigned i, unsigned id)
+{ (void)p; (void)d; (void)i; (void)id; return 0; }
+
+static void *load_sym(void *handle, const char *name)
+{
+    void *sym = dlsym(handle, name);
+    if (!sym)
+    {
+        fprintf(stderr, "ERROR: Missing symbol: %s\n", name);
+        exit(1);
+    }
+    return sym;
+}
+
+static uint8_t *make_dummy_rom(size_t *size_out)
+{
+    size_t sz = 12288;
+    uint8_t *rom = calloc(1, sz);
+    if (!rom) { perror("calloc"); exit(1); }
+    rom[0x404] = 0x00; rom[0x405] = 0x80;
+    rom[0x406] = 0x20; rom[0x407] = 0x00;
+    rom[0x2000] = 0x60; rom[0x2001] = 0xFE;
+    *size_out = sz;
+    return rom;
+}
+
+int main(int argc, char **argv)
+{
+    void *handle;
+    retro_init_t core_init;
+    retro_deinit_t core_deinit;
+    retro_set_environment_t core_set_env;
+    retro_set_video_refresh_t core_set_video;
+    retro_set_audio_sample_t core_set_audio;
+    retro_set_audio_sample_batch_t core_set_audio_batch;
+    retro_set_input_poll_t core_set_input_poll;
+    retro_set_input_state_t core_set_input_state;
+    retro_load_game_t core_load_game;
+    retro_unload_game_t core_unload_game;
+    retro_get_memory_data_t core_get_memory_data;
+    retro_get_memory_size_t core_get_memory_size;
+    struct retro_game_info info;
+    uint8_t *rom;
+    size_t rom_size;
+    rc_libretro_memory_regions_t regions;
+    uint8_t *sysram;
+    uint8_t buf[4];
+    uint32_t avail;
+    uint8_t *pfind;
+    int failures = 0;
+    int mmap_ok;
+    int regions_inited = 0;
+
+    if (argc < 2)
+    {
+        fprintf(stderr, "Usage: %s <core.so|dylib>\n", argv[0]);
+        return 1;
+    }
+
+    handle = dlopen(argv[1], RTLD_LAZY);
+    if (!handle) { fprintf(stderr, "dlopen: %s\n", dlerror()); return 1; }
+
+    core_init             = (retro_init_t)load_sym(handle, "retro_init");
+    core_deinit           = (retro_deinit_t)load_sym(handle, "retro_deinit");
+    core_set_env          = (retro_set_environment_t)load_sym(handle, "retro_set_environment");
+    core_set_video        = (retro_set_video_refresh_t)load_sym(handle, "retro_set_video_refresh");
+    core_set_audio        = (retro_set_audio_sample_t)load_sym(handle, "retro_set_audio_sample");
+    core_set_audio_batch  = (retro_set_audio_sample_batch_t)load_sym(handle, "retro_set_audio_sample_batch");
+    core_set_input_poll   = (retro_set_input_poll_t)load_sym(handle, "retro_set_input_poll");
+    core_set_input_state  = (retro_set_input_state_t)load_sym(handle, "retro_set_input_state");
+    core_load_game        = (retro_load_game_t)load_sym(handle, "retro_load_game");
+    core_unload_game      = (retro_unload_game_t)load_sym(handle, "retro_unload_game");
+    core_get_memory_data  = (retro_get_memory_data_t)load_sym(handle, "retro_get_memory_data");
+    core_get_memory_size  = (retro_get_memory_size_t)load_sym(handle, "retro_get_memory_size");
+
+    g_mmap = NULL;
+    g_get_memory_data = core_get_memory_data;
+    g_get_memory_size = core_get_memory_size;
+
+    core_set_env(env_cb);
+    core_set_video(video_cb);
+    core_set_audio(audio_cb);
+    core_set_audio_batch(audio_batch);
+    core_set_input_poll(input_poll);
+    core_set_input_state(input_state);
+    core_init();
+
+    rom = make_dummy_rom(&rom_size);
+    memset(&info, 0, sizeof(info));
+    info.path = "dummy.j64";
+    info.data = rom;
+    info.size = rom_size;
+
+    if (!core_load_game(&info))
+    {
+        fprintf(stderr, "retro_load_game failed\n");
+        free(rom);
+        core_deinit();
+        dlclose(handle);
+        return 1;
+    }
+
+    mmap_ok = (g_mmap != NULL && g_mmap->descriptors != NULL
+               && g_mmap->num_descriptors >= 1);
+
+    printf("Test 1: SET_MEMORY_MAPS captured ... ");
+    if (!mmap_ok)
+    {
+        printf("FAIL\n");
+        failures++;
+    }
+    else
+        printf("PASS\n");
+
+    memset(&regions, 0, sizeof(regions));
+
+    if (!mmap_ok)
+    {
+        printf("Test 2: rc_libretro_memory_init(Jaguar) ... SKIPPED (no SET_MEMORY_MAPS)\n");
+        printf("Test 3: rc_libretro_memory_read(0xABCD) ... SKIPPED\n");
+        printf("Test 4: rc_libretro_memory_find(0xABCD) matches host ptr ... SKIPPED\n");
+        printf("Test 5: cross-boundary read at end of RAM ... SKIPPED\n");
+        printf("Test 6: rc_libretro_memory_find_avail ... SKIPPED\n");
+    }
+    else
+    {
+        printf("Test 2: rc_libretro_memory_init(Jaguar) ... ");
+        if (!rc_libretro_memory_init(&regions, g_mmap, libretro_get_core_memory_info,
+                                     RC_CONSOLE_ATARI_JAGUAR))
+        {
+            printf("FAIL\n");
+            failures++;
+        }
+        else
+        {
+            printf("PASS\n");
+            regions_inited = 1;
+        }
+
+        if (!regions_inited)
+        {
+            printf("Test 3: rc_libretro_memory_read(0xABCD) ... SKIPPED\n");
+            printf("Test 4: rc_libretro_memory_find(0xABCD) matches host ptr ... SKIPPED\n");
+            printf("Test 5: cross-boundary read at end of RAM ... SKIPPED\n");
+            printf("Test 6: rc_libretro_memory_find_avail ... SKIPPED\n");
+        }
+        else
+        {
+            sysram = (uint8_t *)core_get_memory_data(RETRO_MEMORY_SYSTEM_RAM);
+            if (sysram)
+            {
+                sysram[0xABCD] = 0x42;
+                sysram[0x1FFFFE] = 0x11;
+                sysram[0x1FFFFF] = 0x22;
+            }
+
+            printf("Test 3: rc_libretro_memory_read(0xABCD) ... ");
+            memset(buf, 0, sizeof(buf));
+            if (rc_libretro_memory_read(&regions, 0xABCDU, buf, 1) == 1 && buf[0] == 0x42)
+                printf("PASS\n");
+            else
+            {
+                printf("FAIL\n");
+                failures++;
+            }
+
+            printf("Test 4: rc_libretro_memory_find(0xABCD) matches host ptr ... ");
+            pfind = rc_libretro_memory_find(&regions, 0xABCDU);
+            if (sysram && pfind == sysram + 0xABCD)
+                printf("PASS\n");
+            else
+            {
+                printf("FAIL\n");
+                failures++;
+            }
+
+            printf("Test 5: cross-boundary read at end of RAM ... ");
+            memset(buf, 0, sizeof(buf));
+            if (rc_libretro_memory_read(&regions, 0x1FFFFEU, buf, 2) == 2
+                && buf[0] == 0x11 && buf[1] == 0x22)
+                printf("PASS\n");
+            else
+            {
+                printf("FAIL\n");
+                failures++;
+            }
+
+            printf("Test 6: rc_libretro_memory_find_avail ... ");
+            pfind = rc_libretro_memory_find_avail(&regions, 0x1FFFFEU, &avail);
+            if (pfind && avail >= 2 && sysram && pfind == sysram + 0x1FFFFE)
+                printf("PASS\n");
+            else
+            {
+                printf("FAIL\n");
+                failures++;
+            }
+        }
+
+        if (regions_inited)
+            rc_libretro_memory_destroy(&regions);
+    }
+
+    core_unload_game();
+    core_deinit();
+    free(rom);
+    dlclose(handle);
+
+    printf("\n%s: %d test(s) failed.\n", failures ? "FAIL" : "OK", failures);
+    return failures ? 1 : 0;
+}

--- a/test/tools/test_rcheevos_e2e.sh
+++ b/test/tools/test_rcheevos_e2e.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# End-to-end check: load the core, capture SET_MEMORY_MAPS, run rcheevos rc_libretro
+# memory initialization (same path RetroArch uses for Jaguar / console 17), then read
+# bytes via rc_libretro_memory_read / rc_libretro_memory_find.
+#
+# Requires: bash, curl, cc, ar, libdl (Linux, for dlopen via -ldl)
+# Usage: ./test/tools/test_rcheevos_e2e.sh path/to/virtualjaguar_libretro.{so,dylib}
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CORE="${1:?Usage: $0 path/to/core}"
+export CC="${CC:-cc}"
+
+"$ROOT/test/tools/build_rcheevos_static.sh"
+
+DEST="${DEST:-$ROOT/build/rcheevos-static}"
+LIBRC="$DEST/librcheevos.a"
+
+if [[ "$(uname)" == Linux ]]; then
+   LDFLAGS="-ldl"
+else
+   LDFLAGS=""
+fi
+
+$CC -O2 -Wall \
+   -I"$ROOT/libretro-common/include" \
+   -I"$DEST/rcheevos-src/include" \
+   -I"$DEST/rcheevos-src/src" \
+   -o "$ROOT/build/test_rcheevos_e2e" \
+   "$ROOT/test/tools/test_rcheevos_e2e.c" \
+   "$LIBRC" \
+   $LDFLAGS
+
+"$ROOT/build/test_rcheevos_e2e" "$CORE"


### PR DESCRIPTION
## Summary

General emulation fixes extracted from the CD development branch — **no CD-specific code included**. These fix games like the 240p test suite that were showing black screen / cyan bar.

- **TOM resolution**: Use actual HDB1/HDE/VDB/VDE register values instead of hardcoded constants. Fixes non-standard display windows.
- **68K MULL/DIVL**: Emulate 68020 multiply/divide via IllegalOpcode trap for m68k-atari-mint-gcc toolchain games.
- **68K BSR.L**: Fix for Atari `aln` linker which writes absolute addresses into BSR.L displacement.
- **RAM init**: Skip randomization over loaded executable region during JaguarReset(), fixing RAM-loaded ABS/COFF files.
- **Logging**: Add libretro log interface (`src/log.h`) with LOG_DBG/INF/WRN/ERR macros, toggleable in RetroArch UI.
- **Audio fix**: Disable JERRY_TRACE_DEBUG (was fprintf on every 44kHz interrupt causing slowdown).
- **GPU**: Add GPU_TRACE_DEBUG guard for trace output.

## Test plan

- [ ] 240p test suite boots and displays correctly (no black screen / cyan bar)
- [ ] Existing cart games still work (Tempest 2000, Rayman, Doom, etc.)
- [ ] RetroArch logging verbosity toggle works
- [ ] RAM-loaded executables (ABS/COFF) survive JaguarReset()
- [ ] CI builds pass (GCC + Clang)

🤖 Generated with [Claude Code](https://claude.com/claude-code)